### PR TITLE
Adds source manager, spans to nodes, and pretty printer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,15 @@
+FetchContent_Declare(
+    CLI11
+    GIT_REPOSITORY https://github.com/CLIUtils/CLI11
+    GIT_TAG v2.6.1
+)
+
+FetchContent_MakeAvailable(CLI11)
+
 add_subdirectory(ast)
 add_subdirectory(loxmc)
 add_subdirectory(lexer)
 add_subdirectory(memory)
 add_subdirectory(node)
 add_subdirectory(parser)
+add_subdirectory(source)

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,8 +1,17 @@
-loxmocha_add_library(ast decl.cpp expr.cpp module.cpp pattern.cpp stmt.cpp type.cpp)
+loxmocha_add_library(ast
+    decl.cpp
+    expr.cpp
+    module.cpp
+    pattern.cpp
+    pretty_printer.cpp
+    stmt.cpp
+    type.cpp
+)
 
 target_link_libraries(loxmocha_ast
     PUBLIC
     loxmocha::lexer
     loxmocha::memory
     loxmocha::node
+    loxmocha::source
 )

--- a/src/ast/include/loxmocha/ast/base.hpp
+++ b/src/ast/include/loxmocha/ast/base.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "loxmocha/node.hpp"
+
+#include <string_view>
+
+namespace loxmocha {
+
+using node_base_t = std::string_view;
+
+template<typename... Kinds>
+class ast_node_t : public node_t<node_base_t, Kinds...> {
+public:
+    using node_t<node_base_t, Kinds...>::node_t;
+};
+
+} // namespace loxmocha

--- a/src/ast/include/loxmocha/ast/decl.hpp
+++ b/src/ast/include/loxmocha/ast/decl.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "loxmocha/ast/base.hpp"
 #include "loxmocha/ast/expr.hpp"
 #include "loxmocha/ast/pattern.hpp"
 #include "loxmocha/ast/token.hpp"
 #include "loxmocha/ast/type.hpp"
 #include "loxmocha/memory/safe_pointer.hpp"
-#include "loxmocha/node.hpp"
 
 #include <utility>
 #include <vector>
@@ -105,7 +105,7 @@ public:
      */
     struct parameter_t {
         token_t                name;
-        safe_ptr<type::type_t> type;
+        type::type_t type;
     };
 
     /**
@@ -308,9 +308,9 @@ private:
  *
  * A declaration is either a type declaration, function declaration or variable declaration.
  */
-class decl_t : public node_t<type_t, function_t, variable_t, error_t> {
+class decl_t : public ast_node_t<type_t, function_t, variable_t, error_t> {
 public:
-    using node_t::node_t;
+    using ast_node_t::ast_node_t;
 };
 
 } // namespace loxmocha::decl

--- a/src/ast/include/loxmocha/ast/decl.hpp
+++ b/src/ast/include/loxmocha/ast/decl.hpp
@@ -104,7 +104,7 @@ public:
      * @brief Struct representing a function parameter.
      */
     struct parameter_t {
-        token_t                name;
+        token_t      name;
         type::type_t type;
     };
 

--- a/src/ast/include/loxmocha/ast/expr.hpp
+++ b/src/ast/include/loxmocha/ast/expr.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "loxmocha/ast/base.hpp"
 #include "loxmocha/ast/token.hpp"
 #include "loxmocha/memory/safe_pointer.hpp"
-#include "loxmocha/node.hpp"
 
 #include <vector>
 
@@ -958,35 +958,27 @@ public:
  * @brief represents an expression.
  */
 class expr_t
-    : public node_t<literal_t,
-                    identifier_t,
-                    binary_t,
-                    is_t,
-                    cast_t,
-                    unary_t,
-                    index_t,
-                    field_t,
-                    // closure_t,
-                    call_t,
-                    array_t,
-                    record_t,
-                    tuple_t,
-                    grouping_t,
-                    if_t,
-                    // for_t,
-                    while_t,
-                    block_t,
-                    error_t> {
+    : public ast_node_t<literal_t,
+                        identifier_t,
+                        binary_t,
+                        is_t,
+                        cast_t,
+                        unary_t,
+                        index_t,
+                        field_t,
+                        // closure_t,
+                        call_t,
+                        array_t,
+                        record_t,
+                        tuple_t,
+                        grouping_t,
+                        if_t,
+                        // for_t,
+                        while_t,
+                        block_t,
+                        error_t> {
 public:
-    using node_t::node_t;
-
-    expr_t(const expr_t&)     = delete;
-    expr_t(expr_t&&) noexcept = default;
-
-    ~expr_t() = default;
-
-    auto operator=(const expr_t&) -> expr_t&     = delete;
-    auto operator=(expr_t&&) noexcept -> expr_t& = default;
+    using ast_node_t::ast_node_t;
 };
 
 struct record_t::field_t {
@@ -1000,8 +992,8 @@ struct call_t::named_arg_t {
 };
 
 struct if_t::conditional_branch_t {
-    safe_ptr<expr_t> condition;
-    safe_ptr<expr_t> then_branch;
+    expr_t condition;
+    expr_t then_branch;
 };
 
 } // namespace loxmocha::expr

--- a/src/ast/include/loxmocha/ast/pattern.hpp
+++ b/src/ast/include/loxmocha/ast/pattern.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "loxmocha/ast/base.hpp"
 #include "loxmocha/ast/token.hpp"
 #include "loxmocha/memory/safe_pointer.hpp"
-#include "loxmocha/ast/base.hpp"
 
 namespace loxmocha::type {
 class type_t;

--- a/src/ast/include/loxmocha/ast/pattern.hpp
+++ b/src/ast/include/loxmocha/ast/pattern.hpp
@@ -2,7 +2,7 @@
 
 #include "loxmocha/ast/token.hpp"
 #include "loxmocha/memory/safe_pointer.hpp"
-#include "loxmocha/node.hpp"
+#include "loxmocha/ast/base.hpp"
 
 namespace loxmocha::type {
 class type_t;
@@ -140,9 +140,9 @@ public:
  * @class pattern_t
  * @brief represents a pattern.
  */
-class pattern_t : public node_t<identifier_t, tag_t, error_t> {
+class pattern_t : public ast_node_t<identifier_t, tag_t, error_t> {
 public:
-    using node_t::node_t;
+    using ast_node_t::ast_node_t;
 
     pattern_t(const pattern_t&)     = delete;
     pattern_t(pattern_t&&) noexcept = default;

--- a/src/ast/include/loxmocha/ast/pretty_printer.hpp
+++ b/src/ast/include/loxmocha/ast/pretty_printer.hpp
@@ -1,0 +1,225 @@
+#pragma once
+
+#include "loxmocha/ast/decl.hpp"
+#include "loxmocha/ast/expr.hpp"
+#include "loxmocha/ast/pattern.hpp"
+#include "loxmocha/ast/stmt.hpp"
+#include "loxmocha/ast/type.hpp"
+#include "loxmocha/source/source.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <ostream>
+#include <ranges>
+#include <utility>
+
+namespace loxmocha {
+
+class pretty_printer_t {
+public:
+    void operator()(node_base_t                     span,
+                    const decl::type_t&             decl,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const decl::function_t&         decl,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const decl::variable_t&         decl,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const decl::error_t&            decl,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::literal_t&          expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::identifier_t&       expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::binary_t&           expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void
+    operator()(node_base_t span, const expr::is_t& expr, const source::source_manager_t& source, std::ostream& stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::cast_t&             expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::unary_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::index_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::field_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::call_t&             expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::array_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::record_t&           expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::tuple_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::grouping_t&         expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void
+    operator()(node_base_t span, const expr::if_t& expr, const source::source_manager_t& source, std::ostream& stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::while_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::block_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const expr::error_t&            expr,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const pattern::identifier_t&    pattern,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const pattern::tag_t&           pattern,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const pattern::error_t&         pattern,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const stmt::expr_t&             stmt,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const stmt::assign_t&           stmt,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const stmt::decl_t&             stmt,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::identifier_t&       type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::array_t&            type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::tuple_t&            type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::record_t&           type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::tagged_t&           type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::reference_t&        type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::function_t&         type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+    void operator()(node_base_t                     span,
+                    const type::mutable_t&          type,
+                    const source::source_manager_t& source,
+                    std::ostream&                   stream);
+
+private:
+    [[nodiscard]] auto make_indent() -> std::string
+    {
+        std::string indent{};
+
+        for (const auto [index, isLast] : std::views::enumerate(indent_stack_)) {
+            if (static_cast<std::size_t>(index) == indent_stack_.size() - 1) {
+                indent += isLast ? "└──" : "├──";
+            } else {
+                indent += isLast ? "   " : "│  ";
+            }
+        }
+
+        return indent;
+    }
+
+    [[nodiscard]] static auto get_location(const source::source_manager_t& source, std::string_view span) -> std::string
+    {
+        auto file = source.find_source(span);
+        if (file == source.end()) {
+            return "<unknown file>";
+        }
+
+        if (auto loc = file.view().find_span_location(span); loc) {
+            return std::format(
+                "{}:{}:{}", file.view().filepath().filename().string(), loc->first.line, loc->first.column);
+        }
+
+        return std::format("{}:<unknown location>", file.view().filepath().filename().string());
+    }
+
+    std::vector<bool> indent_stack_;
+};
+
+} // namespace loxmocha

--- a/src/ast/include/loxmocha/ast/stmt.hpp
+++ b/src/ast/include/loxmocha/ast/stmt.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "loxmocha/ast/base.hpp"
 #include "loxmocha/memory/safe_pointer.hpp"
-#include "loxmocha/node.hpp"
 
 namespace loxmocha::expr {
 class expr_t;
@@ -158,9 +158,9 @@ private:
  * @class stmt_t
  * @brief represents a statement
  */
-class stmt_t : public node_t<expr_t, assign_t, decl_t> {
+class stmt_t : public ast_node_t<expr_t, assign_t, decl_t> {
 public:
-    using node_t::node_t;
+    using ast_node_t::ast_node_t;
 
     stmt_t(const stmt_t&)     = delete;
     stmt_t(stmt_t&&) noexcept = default;

--- a/src/ast/include/loxmocha/ast/type.hpp
+++ b/src/ast/include/loxmocha/ast/type.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "loxmocha/ast/base.hpp"
 #include "loxmocha/ast/token.hpp"
 #include "loxmocha/memory/safe_pointer.hpp"
-#include "loxmocha/node.hpp"
 
 #include <vector>
 
@@ -412,9 +412,10 @@ private:
  * @class type_t
  * @brief represents a type expression.
  */
-class type_t : public node_t<identifier_t, array_t, tuple_t, record_t, tagged_t, reference_t, function_t, mutable_t> {
+class type_t
+    : public ast_node_t<identifier_t, array_t, tuple_t, record_t, tagged_t, reference_t, function_t, mutable_t> {
 public:
-    using node_t::node_t;
+    using ast_node_t::ast_node_t;
 
     type_t(const type_t&)     = delete;
     type_t(type_t&&) noexcept = default;

--- a/src/ast/pretty_printer.cpp
+++ b/src/ast/pretty_printer.cpp
@@ -1,0 +1,786 @@
+#include "loxmocha/ast/pretty_printer.hpp"
+
+#include "loxmocha/ast/base.hpp"
+#include "loxmocha/ast/decl.hpp"
+#include "loxmocha/ast/expr.hpp"
+#include "loxmocha/ast/pattern.hpp"
+#include "loxmocha/ast/stmt.hpp"
+#include "loxmocha/ast/type.hpp"
+#include "loxmocha/source/source.hpp"
+
+#include <cstddef>
+#include <ostream>
+#include <ranges>
+
+namespace loxmocha {
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const decl::type_t&             decl,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "─Type Declaration: name: \"" << decl.identifier().span() << "\" at "
+           << get_location(source, span) << '\n';
+    indent_stack_.push_back(true);
+    decl.type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const decl::function_t&         decl,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Function Declaration: name: \"" << decl.identifier().span() << "\" at "
+           << get_location(source, span) << '\n';
+
+    // Parameters
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Parameters:\n";
+    if (decl.parameters().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, param] : std::views::enumerate(decl.parameters())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == decl.parameters().size() - 1);
+            stream << make_indent() << "┬Parameter: name: \"" << param.name.span() << "\" at "
+                   << get_location(source, param.name.span()) << '\n';
+            indent_stack_.push_back(true);
+            param.type.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+
+    // Return type
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Return Type:\n";
+    indent_stack_.push_back(true);
+    decl.return_type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Body
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Function Body:\n";
+    indent_stack_.push_back(true);
+    decl.body()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const decl::variable_t&         decl,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Variable Declaration: name: \"" << decl.identifier().span() << "\" ("
+           << (decl.mutability() == decl::variable_t::mut_e::let ? "let" : "var") << ") at "
+           << get_location(source, span) << '\n';
+
+    // Type
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Type:\n";
+    indent_stack_.push_back(true);
+    decl.type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Initialiser
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Initialiser:\n";
+    indent_stack_.push_back(true);
+    decl.initialiser()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const decl::error_t&            decl,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "─Error Declaration: \"" << decl.message() << "\" at " << get_location(source, span)
+           << '\n';
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::literal_t&          expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "─Literal Expression: value: \"" << expr.value().span() << "\" at "
+           << get_location(source, span) << '\n';
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::identifier_t&       expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "─Identifier Expression: name: \"" << expr.name().span() << "\" at "
+           << get_location(source, span) << '\n';
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::binary_t&           expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Binary Expression: operator: \"" << expr.op().span() << "\" at "
+           << get_location(source, span) << '\n';
+
+    // Left operand
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Left Operand:\n";
+    indent_stack_.push_back(true);
+    expr.left()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Right operand
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Right Operand:\n";
+    indent_stack_.push_back(true);
+    expr.right()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::is_t&               expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Is Expression at " << get_location(source, span) << '\n';
+
+    // Left expression
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Expression:\n";
+    indent_stack_.push_back(true);
+    expr.expr()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Pattern
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Pattern:\n";
+    indent_stack_.push_back(true);
+    expr.pattern()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::cast_t&             expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Cast Expression at " << get_location(source, span) << '\n';
+
+    // Left expression
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Expression:\n";
+    indent_stack_.push_back(true);
+    expr.expr()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Type
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Type:\n";
+    indent_stack_.push_back(true);
+    expr.type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::unary_t&            expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Unary Expression: operator: \"" << expr.op().span() << "\" at "
+           << get_location(source, span) << '\n';
+
+    // Operand
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Operand:\n";
+    indent_stack_.push_back(true);
+    expr.operand()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::index_t&            expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Index Expression at " << get_location(source, span) << '\n';
+
+    // Base expression
+    indent_stack_.push_back(false);
+    stream << make_indent() << "─Base Expression:\n";
+    indent_stack_.push_back(true);
+    expr.base()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Index expression
+    indent_stack_.push_back(true);
+    stream << make_indent() << "─Index Expression:\n";
+    indent_stack_.push_back(true);
+    expr.index()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::field_t&            expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Field Access Expression: field name: \"" << expr.field_name().span() << "\" at "
+           << get_location(source, span) << '\n';
+
+    // Base expression
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Base Expression:\n";
+    indent_stack_.push_back(true);
+    expr.base()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::call_t&             expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Call Expression at " << get_location(source, span) << '\n';
+
+    // Callee expression
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Callee Expression:\n";
+    indent_stack_.push_back(true);
+    expr.callee()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Positional arguments
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Positional Arguments:\n";
+    if (expr.positional_args().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, arg] : std::views::enumerate(expr.positional_args())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == expr.positional_args().size() - 1);
+            stream << make_indent() << "┬Argument " << index << ":\n";
+            indent_stack_.push_back(true);
+            arg.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+
+    // Named arguments
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Named Arguments:\n";
+    if (expr.named_args().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, arg] : std::views::enumerate(expr.named_args())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == expr.named_args().size() - 1);
+            stream << make_indent() << "┬Argument \"" << arg.name.span() << "\":\n";
+            indent_stack_.push_back(true);
+            arg.value.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::array_t&            expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Array Expression at " << get_location(source, span) << '\n';
+
+    // Elements
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Elements:\n";
+    if (expr.elements().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, element] : std::views::enumerate(expr.elements())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == expr.elements().size() - 1);
+            stream << make_indent() << "┬Element " << index << ":\n";
+            indent_stack_.push_back(true);
+            element.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::record_t&           expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Record Expression at " << get_location(source, span) << '\n';
+
+    // Fields
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Fields:\n";
+    if (expr.fields().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, field] : std::views::enumerate(expr.fields())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == expr.fields().size() - 1);
+            stream << make_indent() << "┬Field \"" << field.name.span() << "\":\n";
+            indent_stack_.push_back(true);
+            field.value.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::tuple_t&            expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Tuple Expression at " << get_location(source, span) << '\n';
+
+    // Elements
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Elements:\n";
+    if (expr.elements().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, element] : std::views::enumerate(expr.elements())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == expr.elements().size() - 1);
+            stream << make_indent() << "┬Element " << index << ":\n";
+            indent_stack_.push_back(true);
+            element.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::grouping_t&         expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Grouping Expression at " << get_location(source, span) << '\n';
+
+    // Inner expression
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Inner Expression:\n";
+    indent_stack_.push_back(true);
+    expr.expression()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::if_t&               expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬If Expression at " << get_location(source, span) << '\n';
+
+    // Conditional branches
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Conditional Branches:\n";
+    for (const auto& [index, branch] : std::views::enumerate(expr.conditional_branches())) {
+        indent_stack_.push_back(static_cast<std::size_t>(index) == expr.conditional_branches().size() - 1);
+        stream << make_indent() << "┬Branch " << index << ":\n";
+
+        // Condition
+        indent_stack_.push_back(false);
+        stream << make_indent() << "┬Condition:\n";
+        indent_stack_.push_back(true);
+        branch.condition.visit(*this, source, stream);
+        indent_stack_.pop_back();
+        indent_stack_.pop_back();
+
+        // Then branch
+        indent_stack_.push_back(true);
+        stream << make_indent() << "┬Then Branch:\n";
+        indent_stack_.push_back(true);
+        branch.then_branch.visit(*this, source, stream);
+        indent_stack_.pop_back();
+        indent_stack_.pop_back();
+
+        indent_stack_.pop_back();
+    }
+    indent_stack_.pop_back();
+
+    // Else branch
+    if (expr.else_branch()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "┬Else Branch:\n";
+        indent_stack_.push_back(true);
+        expr.else_branch()->visit(*this, source, stream);
+        indent_stack_.pop_back();
+        indent_stack_.pop_back();
+    }
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::while_t&            expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬While Expression at " << get_location(source, span) << '\n';
+
+    // Condition
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Condition:\n";
+    indent_stack_.push_back(true);
+    expr.condition()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Body
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Body:\n";
+    indent_stack_.push_back(true);
+    expr.body()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const expr::block_t&            expr,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Block Expression at " << get_location(source, span) << '\n';
+
+    // Statements
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Statements:\n";
+    if (expr.statements().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, statement] : std::views::enumerate(expr.statements())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == expr.statements().size() - 1);
+            stream << make_indent() << "┬Statement " << index << ":\n";
+            indent_stack_.push_back(true);
+            statement.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+
+    // Return expression
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Return Expression:\n";
+    indent_stack_.push_back(true);
+    expr.return_expr()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                           span,
+                                  [[maybe_unused]] const expr::error_t& expr,
+                                  const source::source_manager_t&       source,
+                                  std::ostream&                         stream)
+{
+    stream << make_indent() << "─Error Expression at " << get_location(source, span) << '\n';
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const pattern::identifier_t&    pattern,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "─Identifier Pattern: name: \"" << pattern.name().span() << "\" at "
+           << get_location(source, span) << '\n';
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const pattern::tag_t&           pattern,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Tag Pattern: tag name: \"" << pattern.name().span() << "\" at "
+           << get_location(source, span) << '\n';
+
+    // Type
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Type:\n";
+    indent_stack_.push_back(true);
+    pattern.type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Inner pattern
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Inner Pattern:\n";
+    indent_stack_.push_back(true);
+    pattern.pattern()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                              span,
+                                  [[maybe_unused]] const pattern::error_t& pattern,
+                                  const source::source_manager_t&          source,
+                                  std::ostream&                            stream)
+{
+    stream << make_indent() << "─Error Pattern at " << get_location(source, span) << '\n';
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const stmt::expr_t&             stmt,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Expression Statement at " << get_location(source, span) << '\n';
+
+    // Expression
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Expression:\n";
+    indent_stack_.push_back(true);
+    stmt.expr()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const stmt::assign_t&           stmt,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Assignment Statement at " << get_location(source, span) << '\n';
+
+    // Target
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Target:\n";
+    indent_stack_.push_back(true);
+    stmt.target()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+
+    // Value
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Value:\n";
+    indent_stack_.push_back(true);
+    stmt.value()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const stmt::decl_t&             stmt,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Declaration Statement at " << get_location(source, span) << '\n';
+
+    // Declaration
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Declaration:\n";
+    indent_stack_.push_back(true);
+    stmt.declaration()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::identifier_t&       type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "─Identifier Type: name: \"" << type.name().span() << "\" at "
+           << get_location(source, span) << '\n';
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::array_t&            type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Array Type at " << get_location(source, span) << '\n';
+
+    // Element type
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Element Type:\n";
+    indent_stack_.push_back(true);
+    type.element_type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::tuple_t&            type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Tuple Type at " << get_location(source, span) << '\n';
+
+    // Element types
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Element Types:\n";
+    if (type.element_types().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, element_type] : std::views::enumerate(type.element_types())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == type.element_types().size() - 1);
+            stream << make_indent() << "┬Element Type " << index << ":\n";
+            indent_stack_.push_back(true);
+            element_type.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::record_t&           type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Record Type at " << get_location(source, span) << '\n';
+
+    // Fields
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Fields:\n";
+    if (type.fields().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "─<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, field] : std::views::enumerate(type.fields())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == type.fields().size() - 1);
+            stream << make_indent() << "┬Field \"" << field.name.span() << "\":\n";
+            indent_stack_.push_back(true);
+            field.type.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::tagged_t&           type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Tagged Type at " << get_location(source, span) << '\n';
+
+    // Choices
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Choices:\n";
+    for (const auto& [index, tag] : std::views::enumerate(type.tags())) {
+        indent_stack_.push_back(static_cast<std::size_t>(index) == type.tags().size() - 1);
+        stream << make_indent() << "┬Choice \"" << tag.name.span() << "\":\n";
+        indent_stack_.push_back(true);
+        tag.type.visit(*this, source, stream);
+        indent_stack_.pop_back();
+        indent_stack_.pop_back();
+    }
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::reference_t&        type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Reference Type at " << get_location(source, span) << '\n';
+
+    // Referenced type
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Referenced Type:\n";
+    indent_stack_.push_back(true);
+    type.base_type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::function_t&         type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Function Type at " << get_location(source, span) << '\n';
+
+    // Parameter types
+    indent_stack_.push_back(false);
+    stream << make_indent() << "┬Parameter Types:\n";
+    if (type.parameters().empty()) {
+        indent_stack_.push_back(true);
+        stream << make_indent() << "<none>\n";
+        indent_stack_.pop_back();
+    } else {
+        for (const auto& [index, param_type] : std::views::enumerate(type.parameters())) {
+            indent_stack_.push_back(static_cast<std::size_t>(index) == type.parameters().size() - 1);
+            stream << make_indent() << "┬Parameter Type " << index << ":\n";
+            indent_stack_.push_back(true);
+            param_type.visit(*this, source, stream);
+            indent_stack_.pop_back();
+            indent_stack_.pop_back();
+        }
+    }
+    indent_stack_.pop_back();
+
+    // Return type
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Return Type:\n";
+    indent_stack_.push_back(true);
+    type.return_type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+void pretty_printer_t::operator()(node_base_t                     span,
+                                  const type::mutable_t&          type,
+                                  const source::source_manager_t& source,
+                                  std::ostream&                   stream)
+{
+    stream << make_indent() << "┬Mutable Type at " << get_location(source, span) << '\n';
+
+    // Inner type
+    indent_stack_.push_back(true);
+    stream << make_indent() << "┬Inner Type:\n";
+    indent_stack_.push_back(true);
+    type.base_type()->visit(*this, source, stream);
+    indent_stack_.pop_back();
+    indent_stack_.pop_back();
+}
+
+} // namespace loxmocha

--- a/src/loxmc/CMakeLists.txt
+++ b/src/loxmc/CMakeLists.txt
@@ -2,5 +2,7 @@ loxmocha_add_executable(loxmc main.cpp)
 
 target_link_libraries(loxmocha_loxmc
     PRIVATE
-    loxmocha::lexer
+    loxmocha::parser
+    loxmocha::source
+    CLI11::CLI11
 )

--- a/src/loxmc/main.cpp
+++ b/src/loxmc/main.cpp
@@ -1,27 +1,93 @@
 #include "loxmocha/ast/lexer.hpp"
-#include "loxmocha/ast/token.hpp"
+#include "loxmocha/ast/parser.hpp"
+#include "loxmocha/memory/safe_pointer.hpp"
+#include "loxmocha/source/source.hpp"
 
-#include <expected>
-#include <format>
+#include <CLI/CLI.hpp>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <iterator>
 #include <print>
+#include <string>
+#include <utility>
 
-auto main() -> int
+namespace {
+auto read_file(const std::string& path) -> std::string
 {
-    auto rename = [](std::expected<loxmocha::token_t, loxmocha::lex_error_t> tok) {
-        if (tok) {
-            return std::format("Success: \"{}\"", tok->span());
-        }
-        return tok.error().message();
-    };
+    std::ifstream file_stream{path};
 
-    std::println("{}", rename(loxmocha::lexer_t{"("}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{"="}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{"=>"}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{"=="}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{"=$"}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{"          \t =$"}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{"$"}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{" my_identifier"}.next_token()));
-    std::println("{}", rename(loxmocha::lexer_t{" my_identifier "}.next_token()));
+    if (!file_stream.is_open()) {
+        throw std::runtime_error{"Could not open file: " + path};
+    }
+
+    std::string content{std::istreambuf_iterator<char>(file_stream), std::istreambuf_iterator<char>()};
+    return content;
+}
+} // namespace
+
+auto main(int argc, char** argv) -> int
+{
+    CLI::App app{"LoxMocha Compiler"};
+
+    std::string source_file{};
+    app.add_option("-f,--file", source_file, "Source file")->required();
+
+    CLI11_PARSE(app, argc, argv);
+
+    loxmocha::source::source_manager_t source_manager{};
+
+    try {
+        std::string source_content = read_file(source_file);
+        auto        source_info =
+            loxmocha::safe_ptr<loxmocha::source::source_info_t>::make(source_file, std::move(source_content));
+        source_manager.emplace(std::move(source_info));
+
+        std::println("Loaded source file: {}", source_file);
+
+        for (const auto& source_view : source_manager) {
+            std::println("File in manager: {}", source_view.filepath().string());
+        }
+
+        auto source_view = *source_manager.find_source(std::filesystem::path{source_file});
+
+        loxmocha::lexer_t lexer{source_manager.find_source(std::filesystem::path{source_file}).view().content()};
+
+        auto parse_result = loxmocha::parse_decl(lexer);
+        if (!parse_result) {
+            for (const auto& error : parse_result.diagnostics()) {
+                std::println(std::cerr, "Parse Error: {}", error);
+            }
+            return 1;
+        }
+
+        auto offset = source_view.content().find("var");
+        auto loc    = source_view.find_location(source_view.content().substr(offset));
+
+        if (loc) {
+            std::println("Source location found: {}:{}:{}", loc->line, loc->column, source_view.filepath().string());
+            auto source_view_2 = source_manager.find_source(loc->line_span).view();
+            std::println("Find source by substring span: {}", source_view_2.filepath().string());
+        } else {
+            std::println("Source location not found.");
+        }
+
+        std::string not_registered_span = "this span does not exist";
+        auto        not_found_view =
+            source_manager.find_source(std::string_view{not_registered_span.begin(), not_registered_span.end()});
+
+        if (not_found_view == source_manager.end()) {
+            std::println("Correctly did not find source for unregistered span.");
+        } else {
+            std::println("Error: Found source for unregistered span.");
+        }
+
+        std::println("Parsing completed successfully.");
+
+    } catch (const std::exception& e) {
+        std::println(std::cerr, "Error: {}", e.what());
+        return 1;
+    }
+
     return 0;
 }

--- a/src/loxmc/main.cpp
+++ b/src/loxmc/main.cpp
@@ -47,9 +47,9 @@ auto main(int argc, char** argv) -> int
         source_manager.emplace(std::move(source_info));
 
         loxmocha::lexer_t lexer(source_manager.find_source(source_file).view().content());
-        auto start_time = std::chrono::high_resolution_clock::now();
+        auto              start_time   = std::chrono::high_resolution_clock::now();
         auto              parse_result = loxmocha::parse_decl(lexer);
-        auto end_time   = std::chrono::high_resolution_clock::now();
+        auto              end_time     = std::chrono::high_resolution_clock::now();
 
         std::println("Parsing took {} microseconds",
                      std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count());

--- a/src/node/include/loxmocha/node.hpp
+++ b/src/node/include/loxmocha/node.hpp
@@ -79,8 +79,9 @@ public:
     template<typename Visitor, typename... Args>
     auto visit(Visitor&& visitor, Args&&... args) const
     {
-        return std::visit(
-            [&visitor, &args...](auto&& arg) -> auto { return visitor(arg, std::forward<Args>(args)...); }, node_);
+        return std::visit([ &base = this->base_, &visitor, &args...](
+                              auto&& arg) -> auto { return visitor(base, arg, std::forward<Args>(args)...); },
+                          node_);
     }
 
     /**
@@ -95,8 +96,9 @@ public:
     template<typename Visitor, typename... Args>
     auto visit(Visitor&& visitor, Args&&... args)
     {
-        return std::visit(
-            [&visitor, &args...](auto&& arg) -> auto { return visitor(arg, std::forward<Args>(args)...); }, node_);
+        return std::visit([&base = this->base_, &visitor, &args...](
+                              auto&& arg) -> auto { return visitor(base, arg, std::forward<Args>(args)...); },
+                          node_);
     }
 
 private:

--- a/src/node/include/loxmocha/node.hpp
+++ b/src/node/include/loxmocha/node.hpp
@@ -79,7 +79,7 @@ public:
     template<typename Visitor, typename... Args>
     auto visit(Visitor&& visitor, Args&&... args) const
     {
-        return std::visit([ &base = this->base_, &visitor, &args...](
+        return std::visit([&base = this->base_, &visitor, &args...](
                               auto&& arg) -> auto { return visitor(base, arg, std::forward<Args>(args)...); },
                           node_);
     }

--- a/src/parser/parser-decl.cpp
+++ b/src/parser/parser-decl.cpp
@@ -1,3 +1,4 @@
+#include "loxmocha/ast/base.hpp"
 #include "loxmocha/ast/decl.hpp"
 #include "loxmocha/ast/parser.hpp"
 #include "loxmocha/ast/token.hpp"
@@ -18,14 +19,15 @@ auto parser_t::parse_decl() -> parser_result_t<decl::decl_t>
 auto parser_t::parse_decl_internal() -> decl::decl_t
 {
     switch (auto token = lexer_.peek_token(); token ? token->kind() : token_t::kind_e::s_eof) {
-    case token_t::kind_e::k_fun: lexer_.consume_token(); return fun_decl();
-    case token_t::kind_e::k_let: lexer_.consume_token(); return item_decl(decl::variable_t::mut_e::let);
-    case token_t::kind_e::k_var: lexer_.consume_token(); return item_decl(decl::variable_t::mut_e::var);
-    case token_t::kind_e::k_type: lexer_.consume_token(); return type_decl();
+    case token_t::kind_e::k_fun: lexer_.consume_token(); return fun_decl(*token);
+    case token_t::kind_e::k_let: lexer_.consume_token(); return item_decl(*token, decl::variable_t::mut_e::let);
+    case token_t::kind_e::k_var: lexer_.consume_token(); return item_decl(*token, decl::variable_t::mut_e::var);
+    case token_t::kind_e::k_type: lexer_.consume_token(); return type_decl(*token);
     default:
+        lexer_.consume_token();
         has_error_ = true;
         diagnostics_.emplace_back("Expected declaration");
-        return decl::error_t{"Invalid declaration"};
+        return decl::decl_t{node_base_t{token->span()}, decl::error_t{"Invalid declaration"}};
     }
 }
 
@@ -40,19 +42,19 @@ auto parser_t::is_decl_start_token(const token_t& token) -> bool
     }
 }
 
-auto parser_t::fun_decl() -> decl::decl_t
+auto parser_t::fun_decl(loxmocha::token_t fun) -> decl::decl_t
 {
     // We expect a function to start with an identifier and an opening paren.
     auto name = expect_token<token_t::kind_e::k_identifier>();
     if (!name) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected function name in function declaration");
-        return decl::error_t{"Invalid function declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid function declaration"}};
     }
     if (!expect_token<token_t::kind_e::p_left_paren>()) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected '(' after function name in function declaration");
-        return decl::error_t{"Invalid function declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid function declaration"}};
     }
 
     auto params =
@@ -66,63 +68,75 @@ auto parser_t::fun_decl() -> decl::decl_t
                     diagnostics_.emplace_back("Expected parameter name in function declaration");
                     return decl::function_t::parameter_t{
                         .name = token_t::k_identifier("<error>"),
-                        .type = safe_ptr<type::type_t>::make(type::identifier_t{token_t::k_identifier("<error>")})};
+                        .type = type::type_t{"", type::identifier_t{token_t::k_identifier("<error>")}}};
                 }
                 if (!expect_token<token_t::kind_e::p_colon>()) {
                     has_error_ = true;
                     diagnostics_.emplace_back("Expected ':' after parameter name in function declaration");
                     return decl::function_t::parameter_t{
                         .name = *param_name,
-                        .type = safe_ptr<type::type_t>::make(type::identifier_t{token_t::k_identifier("<error>")})};
+                        .type = type::type_t{"", type::identifier_t{token_t::k_identifier("<error>")}}};
                 }
-                return decl::function_t::parameter_t{.name = *param_name,
-                                                     .type = safe_ptr<type::type_t>::make(parse_type_internal())};
+                return decl::function_t::parameter_t{.name = *param_name, .type = parse_type_internal()};
             });
 
+    auto right_paren_token = expect_token<token_t::kind_e::p_right_paren>();
+
     // Now we expect and consume the closing parent.
-    if (!expect_token<token_t::kind_e::p_right_paren>()) {
+    if (!right_paren_token) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected ')' after function parameters in function declaration");
-        return decl::error_t{"Invalid function declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid function declaration"}};
     }
 
     // If we have a colon then we parse the return type, otherwise we default to the empty tuple.
-    auto return_type = expect_token<token_t::kind_e::p_colon>() ? safe_ptr<type::type_t>::make(parse_type_internal())
-                                                                : safe_ptr<type::type_t>::make(type::tuple_t{{}});
+    auto return_type =
+        expect_token<token_t::kind_e::p_colon>()
+            ? safe_ptr<type::type_t>::make(parse_type_internal())
+            : safe_ptr<type::type_t>::make(
+                  node_base_t{right_paren_token->span().end(), right_paren_token->span().end()}, type::tuple_t{{}});
 
     // We have two kinds of bodies for function.
     // We either have an expression body which has the entry token '=>'
     if (expect_token<token_t::kind_e::p_arrow>()) {
-        return decl::function_t{
-            *name, std::move(params), std::move(return_type), safe_ptr<expr::expr_t>::make(parse_expr_internal())};
+        auto body = parse_expr_internal();
+        return decl::decl_t{
+            node_base_t{fun.span().begin(), body.base().end()},
+            decl::function_t{
+                *name, std::move(params), std::move(return_type), safe_ptr<expr::expr_t>::make(std::move(body))}};
     }
 
     // Otherwise we have a block body which has the entry token 'begin'.
     // If we do not have a 'begin' token then we will report an error.
-    if (!expect_token<token_t::kind_e::k_begin>()) {
+    auto begin = expect_token<token_t::kind_e::k_begin>();
+    if (!begin) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected 'begin' or '=>' after function signature in function declaration");
-        return decl::error_t{"Invalid function declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid function declaration"}};
     }
 
-    return decl::function_t{
-        *name, std::move(params), std::move(return_type), safe_ptr<expr::expr_t>::make(block_expr())};
+    auto body = block_expr(*begin);
+
+    return decl::decl_t{
+        node_base_t{fun.span().begin(), body.base().end()},
+        decl::function_t{
+            *name, std::move(params), std::move(return_type), safe_ptr<expr::expr_t>::make(std::move(body))}};
 }
 
-auto parser_t::item_decl(decl::variable_t::mut_e mut) -> decl::decl_t
+auto parser_t::item_decl(const token_t& let, decl::variable_t::mut_e mut) -> decl::decl_t
 {
     // We expect a variable to start with an identifier, a colon, a type, an equal sign and an initialiser.
     auto name = expect_token<token_t::kind_e::k_identifier>();
     if (!name) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected variable name in variable declaration");
-        return decl::error_t{"Invalid variable declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid variable declaration"}};
     }
 
     if (!expect_token<token_t::kind_e::p_colon>()) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected ':' after variable name in variable declaration");
-        return decl::error_t{"Invalid variable declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid variable declaration"}};
     }
 
     auto type = safe_ptr<type::type_t>::make(parse_type_internal());
@@ -130,33 +144,34 @@ auto parser_t::item_decl(decl::variable_t::mut_e mut) -> decl::decl_t
     if (!expect_token<token_t::kind_e::p_equal>()) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected '=' after variable type in variable declaration");
-        return decl::error_t{"Invalid variable declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid variable declaration"}};
     }
 
     auto initialiser = safe_ptr<expr::expr_t>::make(parse_expr_internal());
 
-    return decl::variable_t{mut, *name, std::move(type), std::move(initialiser)};
+    return decl::decl_t{{let.span().begin(), initialiser->base().end()},
+                        decl::variable_t{mut, *name, std::move(type), std::move(initialiser)}};
 }
 
-auto parser_t::type_decl() -> decl::decl_t
+auto parser_t::type_decl(loxmocha::token_t type) -> decl::decl_t
 {
     // We expect a type to start with an identifier, an 'is' keyword and a type.
     auto name = expect_token<token_t::kind_e::k_identifier>();
     if (!name) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected type name in type declaration");
-        return decl::error_t{"Invalid type declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid type declaration"}};
     }
 
     if (!expect_token<token_t::kind_e::k_is>()) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected 'is' after type name in type declaration");
-        return decl::error_t{"Invalid type declaration"};
+        return decl::decl_t{"", decl::error_t{"Invalid type declaration"}};
     }
 
-    auto type = safe_ptr<type::type_t>::make(parse_type_internal());
+    auto type_expr = safe_ptr<type::type_t>::make(parse_type_internal());
 
-    return decl::type_t{*name, std::move(type)};
+    return decl::decl_t{{type.span().begin(), type_expr->base().end()}, decl::type_t{*name, std::move(type_expr)}};
 }
 
 } // namespace loxmocha::internal

--- a/src/parser/parser-decl.cpp
+++ b/src/parser/parser-decl.cpp
@@ -24,7 +24,6 @@ auto parser_t::parse_decl_internal() -> decl::decl_t
     case token_t::kind_e::k_var: lexer_.consume_token(); return item_decl(*token, decl::variable_t::mut_e::var);
     case token_t::kind_e::k_type: lexer_.consume_token(); return type_decl(*token);
     default:
-        lexer_.consume_token();
         has_error_ = true;
         diagnostics_.emplace_back("Expected declaration");
         return decl::decl_t{node_base_t{token->span()}, decl::error_t{"Invalid declaration"}};

--- a/src/parser/parser-expr.cpp
+++ b/src/parser/parser-expr.cpp
@@ -69,9 +69,8 @@ auto parser_t::if_expr(loxmocha::token_t if_tok) -> expr::expr_t
         } else if (auto then = expect_token<token_t::kind_e::k_then>(); then) {
             // Parse a block body.
             auto then_branch = block_body(*then);
-            conditional_branches.emplace_back(
-                expr::if_t::conditional_branch_t{.condition   = std::move(condition),
-                                                 .then_branch = std::move(then_branch)});
+            conditional_branches.emplace_back(expr::if_t::conditional_branch_t{.condition   = std::move(condition),
+                                                                               .then_branch = std::move(then_branch)});
 
             // If we have an end token then the if expression is complete.
             if (auto end = expect_token<token_t::kind_e::k_end>(); end) {

--- a/src/parser/parser-expr.cpp
+++ b/src/parser/parser-expr.cpp
@@ -1,3 +1,4 @@
+#include "loxmocha/ast/base.hpp"
 #include "loxmocha/ast/expr.hpp"
 #include "loxmocha/ast/parser.hpp"
 #include "loxmocha/ast/pattern.hpp"
@@ -16,8 +17,10 @@ namespace loxmocha::internal {
 namespace {
     auto construct_binary_expr(const token_t& op, expr::expr_t left, expr::expr_t right) -> expr::expr_t
     {
-        return expr::binary_t{
-            op, safe_ptr<expr::expr_t>::make(std::move(left)), safe_ptr<expr::expr_t>::make(std::move(right))};
+        return expr::expr_t{{left.base().begin(), right.base().end()},
+                            expr::binary_t{op,
+                                           safe_ptr<expr::expr_t>::make(std::move(left)),
+                                           safe_ptr<expr::expr_t>::make(std::move(right))}};
     }
 } // namespace
 
@@ -33,14 +36,14 @@ auto parser_t::parse_expr_internal() -> expr::expr_t
     // Check to see if the start token of the expression is a control flow expression.
     // Otherwise parse it as a normal expression.
     switch (auto token = lexer_.peek_token(); token ? token->kind() : token_t::kind_e::s_eof) {
-    case token_t::kind_e::k_if: lexer_.consume_token(); return if_expr();
-    case token_t::kind_e::k_while: lexer_.consume_token(); return while_expr();
-    case token_t::kind_e::k_begin: lexer_.consume_token(); return block_expr();
+    case token_t::kind_e::k_if: lexer_.consume_token(); return if_expr(*token);
+    case token_t::kind_e::k_while: lexer_.consume_token(); return while_expr(*token);
+    case token_t::kind_e::k_begin: lexer_.consume_token(); return block_expr(*token);
     default: return or_expr();
     }
 }
 
-auto parser_t::if_expr() -> expr::expr_t
+auto parser_t::if_expr(loxmocha::token_t if_tok) -> expr::expr_t
 {
     // If expression parsing is complicated due to the multiple forms and mixing of block or expression bodies.
     // Along with optional dangling else branches, and the flat else-if structure.
@@ -55,41 +58,42 @@ auto parser_t::if_expr() -> expr::expr_t
         // Otherwise we have an invalid if expression and we report an error.
         if (expect_token<token_t::kind_e::p_arrow>()) {
             auto then_branch = parse_expr_internal();
-            conditional_branches.emplace_back(
-                expr::if_t::conditional_branch_t{.condition   = safe_ptr<expr::expr_t>::make(std::move(condition)),
-                                                 .then_branch = safe_ptr<expr::expr_t>::make(std::move(then_branch))});
+            conditional_branches.emplace_back(expr::if_t::conditional_branch_t{.condition   = std::move(condition),
+                                                                               .then_branch = std::move(then_branch)});
 
             // If we do not have an else after just parsing the branch, then the if expression is complete.
             if (!expect_token<token_t::kind_e::k_else>()) {
-                return expr::if_t{std::move(conditional_branches)};
+                const node_base_t span{if_tok.span().begin(), conditional_branches.back().then_branch.base().end()};
+                return expr::expr_t{span, expr::if_t{std::move(conditional_branches)}};
             }
-        } else if (expect_token<token_t::kind_e::k_then>()) {
+        } else if (auto then = expect_token<token_t::kind_e::k_then>(); then) {
             // Parse a block body.
-            auto then_branch = block_body();
+            auto then_branch = block_body(*then);
             conditional_branches.emplace_back(
-                expr::if_t::conditional_branch_t{.condition   = safe_ptr<expr::expr_t>::make(std::move(condition)),
-                                                 .then_branch = safe_ptr<expr::expr_t>::make(std::move(then_branch))});
+                expr::if_t::conditional_branch_t{.condition   = std::move(condition),
+                                                 .then_branch = std::move(then_branch)});
 
             // If we have an end token then the if expression is complete.
-            if (expect_token<token_t::kind_e::k_end>()) {
-                return expr::if_t{std::move(conditional_branches)};
+            if (auto end = expect_token<token_t::kind_e::k_end>(); end) {
+                return expr::expr_t{{if_tok.span().begin(), end->span().end()},
+                                    expr::if_t{std::move(conditional_branches)}};
             }
 
             // Otherwise we expect there to be an else token to continue the if expression.
             if (!expect_token<token_t::kind_e::k_else>()) {
                 has_error_ = true;
                 diagnostics_.emplace_back("Expected 'else' or 'end' after 'if' conditional branch");
-                return expr::error_t{};
+                return expr::expr_t{"", expr::error_t{}};
             }
 
         } else {
             has_error_ = true;
             diagnostics_.emplace_back("Expected '=>' or 'then' after 'if' condition");
-            return expr::error_t{};
+            return expr::expr_t{"", expr::error_t{}};
         }
 
-        // If after parsing the branch and else token we do not have another if token then we only have the else branch
-        // left.
+        // If after parsing the branch and else token we do not have another if token then we only have the else
+        // branch left.
         if (!expect_token<token_t::kind_e::k_if>()) {
             break;
         }
@@ -97,7 +101,10 @@ auto parser_t::if_expr() -> expr::expr_t
 
     auto else_branch = else_body();
 
-    return expr::if_t{std::move(conditional_branches), safe_ptr<expr::expr_t>::make(std::move(else_branch))};
+    const node_base_t span{if_tok.span().begin(), else_branch.base().end()};
+
+    return expr::expr_t{
+        span, expr::if_t{std::move(conditional_branches), safe_ptr<expr::expr_t>::make(std::move(else_branch))}};
 }
 
 auto parser_t::else_body() -> expr::expr_t
@@ -106,53 +113,67 @@ auto parser_t::else_body() -> expr::expr_t
     if (expect_token<token_t::kind_e::p_arrow>()) {
         return parse_expr_internal();
     }
-    return block_expr();
+    auto block = lexer_.peek_token();
+    if (block) {
+        return block_expr(*block);
+    }
+    diagnostics_.emplace_back("Unknown token after 'else'");
+    has_error_ = true;
+    return expr::expr_t{"", expr::error_t{}};
 }
 
-auto parser_t::while_expr() -> expr::expr_t
+auto parser_t::while_expr(loxmocha::token_t while_tok) -> expr::expr_t
 {
     auto condition = or_expr();
 
     // if we have an arrow then we parse an expression body.
     if (expect_token<token_t::kind_e::p_arrow>()) {
-        auto body = parse_expr_internal();
-        return expr::while_t{safe_ptr<expr::expr_t>::make(std::move(condition)),
-                             safe_ptr<expr::expr_t>::make(std::move(body))};
+        auto              body = parse_expr_internal();
+        const node_base_t span{while_tok.span().begin(), body.base().end()};
+        return expr::expr_t{span,
+                            expr::while_t{safe_ptr<expr::expr_t>::make(std::move(condition)),
+                                          safe_ptr<expr::expr_t>::make(std::move(body))}};
     }
 
     // Otherwise we expect a 'then' and parse a block body.
-    if (!expect_token<token_t::kind_e::k_then>()) {
+    auto then = expect_token<token_t::kind_e::k_then>();
+    if (!then) {
         has_error_ = true;
         diagnostics_.emplace_back("Expected '=>' or 'then' after while condition");
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
-    auto body = block_expr();
-    return expr::while_t{safe_ptr<expr::expr_t>::make(std::move(condition)),
-                         safe_ptr<expr::expr_t>::make(std::move(body))};
+    auto              body = block_expr(*then);
+    const node_base_t span{while_tok.span().begin(), body.base().end()};
+    return expr::expr_t{span,
+                        expr::while_t{safe_ptr<expr::expr_t>::make(std::move(condition)),
+                                      safe_ptr<expr::expr_t>::make(std::move(body))}};
 }
 
-auto parser_t::block_expr() -> expr::expr_t
+auto parser_t::block_expr(loxmocha::token_t begin) -> expr::expr_t
 {
     // A block expression has already consumed its entry token.
     // This can be a begin token from an explicit block or a then token from an if or while expression.
-    auto block = block_body();
+    auto block = block_body(begin);
 
     // Block expression must terminate with an end token.
-    if (!expect_token<token_t::kind_e::k_end>()) {
+    auto end = expect_token<token_t::kind_e::k_end>();
+    if (!end) {
         diagnostics_.emplace_back("Expected 'end' after block expression");
         has_error_ = true;
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
+    block.base() = node_base_t{begin.span().begin(), end->span().end()};
     return block;
 }
 
-auto parser_t::block_body() -> expr::expr_t
+auto parser_t::block_body(loxmocha::token_t begin) -> expr::expr_t
 {
     std::vector<stmt::stmt_t> statements{};
     // The default return expression is an empty tuple.
-    auto return_expr = safe_ptr<expr::expr_t>::make(expr::tuple_t{{}});
+    auto return_expr =
+        safe_ptr<expr::expr_t>::make(node_base_t{begin.span().end(), begin.span().end()}, expr::tuple_t{{}});
 
     for (;;) {
         // If we hit an end or else token then it means the block has terminated.
@@ -165,8 +186,9 @@ auto parser_t::block_body() -> expr::expr_t
 
         auto stmt = parse_stmt_internal();
 
-        if (expect_token<token_t::kind_e::p_semicolon>()) {
+        if (auto semicolon = expect_token<token_t::kind_e::p_semicolon>(); semicolon) {
             statements.emplace_back(std::move(stmt));
+            return_expr->base() = semicolon->span();
             continue;
         }
 
@@ -178,10 +200,11 @@ auto parser_t::block_body() -> expr::expr_t
 
         has_error_ = true;
         diagnostics_.emplace_back("Expected ';' or expression at end of statement in block");
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
-    return expr::block_t{std::move(statements), std::move(return_expr)};
+    const node_base_t span{begin.span().begin(), return_expr->base().end()};
+    return expr::expr_t{span, expr::block_t{std::move(statements), std::move(return_expr)}};
 }
 
 auto parser_t::or_expr() -> expr::expr_t
@@ -241,8 +264,10 @@ auto parser_t::is_expr() -> expr::expr_t
         [this]() -> expr::expr_t { return cast_expr(); },
         [this]() -> pattern::pattern_t { return parse_pattern_internal(); },
         [](token_t, expr::expr_t left, pattern::pattern_t right) -> expr::expr_t {
-            return expr::is_t{safe_ptr<expr::expr_t>::make(std::move(left)),
-                              safe_ptr<pattern::pattern_t>::make(std::move(right))};
+            const node_base_t span{left.base().begin(), right.base().end()};
+            return expr::expr_t{span,
+                                expr::is_t{safe_ptr<expr::expr_t>::make(std::move(left)),
+                                           safe_ptr<pattern::pattern_t>::make(std::move(right))}};
         });
 }
 
@@ -250,20 +275,23 @@ auto parser_t::cast_expr() -> expr::expr_t
 {
     // Like is expressions, cast expressions break from our usual
     // binary expression parsing since the rhs is a type.
-    return parse_binary_expr<token_t::kind_e::k_as>([this]() -> expr::expr_t { return unary_expr(); },
-                                                    [this]() -> type::type_t { return parse_type_internal(); },
-                                                    [](token_t, expr::expr_t left, type::type_t right) -> expr::expr_t {
-                                                        return expr::cast_t{
-                                                            safe_ptr<expr::expr_t>::make(std::move(left)),
-                                                            safe_ptr<type::type_t>::make(std::move(right))};
-                                                    });
+    return parse_binary_expr<token_t::kind_e::k_as>(
+        [this]() -> expr::expr_t { return unary_expr(); },
+        [this]() -> type::type_t { return parse_type_internal(); },
+        [](token_t, expr::expr_t left, type::type_t right) -> expr::expr_t {
+            const node_base_t span{left.base().begin(), right.base().end()};
+            return expr::expr_t{span,
+                                expr::cast_t{safe_ptr<expr::expr_t>::make(std::move(left)),
+                                             safe_ptr<type::type_t>::make(std::move(right))}};
+        });
 }
 
 auto parser_t::unary_expr() -> expr::expr_t
 {
     if (auto op_token = expect_token<token_t::kind_e::p_bang, token_t::kind_e::p_minus>()) {
-        auto right = unary_expr();
-        return expr::unary_t{*op_token, safe_ptr<expr::expr_t>::make(std::move(right))};
+        auto              right = unary_expr();
+        const node_base_t span{op_token->span().begin(), right.base().end()};
+        return expr::expr_t{span, expr::unary_t{*op_token, safe_ptr<expr::expr_t>::make(std::move(right))}};
     }
     return access_expr();
 }
@@ -271,25 +299,28 @@ auto parser_t::unary_expr() -> expr::expr_t
 auto parser_t::field_access_expr(expr::expr_t&& base_expr) -> expr::expr_t
 {
     if (auto field = expect_token<token_t::kind_e::k_identifier>()) {
-        return expr::field_t{safe_ptr<expr::expr_t>::make(std::move(base_expr)), *field};
+        const node_base_t span{base_expr.base().begin(), field->span().end()};
+        return expr::expr_t{span, expr::field_t{safe_ptr<expr::expr_t>::make(std::move(base_expr)), *field}};
     }
 
     diagnostics_.emplace_back("Expected identifier after '.'");
     has_error_ = true;
-    return expr::error_t{};
+    return expr::expr_t{"", expr::error_t{}};
 }
 
 auto parser_t::index_expr(expr::expr_t&& base_expr) -> expr::expr_t
 {
     auto index_expr = equality_expr();
-    if (expect_token<token_t::kind_e::p_right_square>()) {
-        return expr::index_t{safe_ptr<expr::expr_t>::make(std::move(base_expr)),
-                             safe_ptr<expr::expr_t>::make(std::move(index_expr))};
+    if (auto right_square = expect_token<token_t::kind_e::p_right_square>(); right_square) {
+        const node_base_t span{base_expr.base().begin(), right_square->span().end()};
+        return expr::expr_t{span,
+                            expr::index_t{safe_ptr<expr::expr_t>::make(std::move(base_expr)),
+                                          safe_ptr<expr::expr_t>::make(std::move(index_expr))}};
     }
 
     diagnostics_.emplace_back("Expected ']' after index expression");
     has_error_ = true;
-    return expr::error_t{};
+    return expr::expr_t{"", expr::error_t{}};
 }
 
 auto parser_t::positional_args() -> std::vector<expr::expr_t>
@@ -370,13 +401,17 @@ auto parser_t::call_expr(expr::expr_t&& callee_expr) -> expr::expr_t
     auto named      = named_args();
 
     // Finally we must have a closing paren.
-    if (!expect_token<token_t::kind_e::p_right_paren>()) {
+    auto right_paren = expect_token<token_t::kind_e::p_right_paren>();
+    if (!right_paren) {
         diagnostics_.emplace_back("Expected ')' after arguments");
         has_error_ = true;
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
-    return expr::call_t{safe_ptr<expr::expr_t>::make(std::move(callee_expr)), std::move(positional), std::move(named)};
+    const node_base_t span{callee_expr.base().begin(), right_paren->span().end()};
+    return expr::expr_t{
+        span,
+        expr::call_t{safe_ptr<expr::expr_t>::make(std::move(callee_expr)), std::move(positional), std::move(named)}};
 }
 
 auto parser_t::access_expr() -> expr::expr_t
@@ -410,7 +445,7 @@ auto parser_t::primary_expr() -> expr::expr_t
     if (!lexer_.peek_token() || lexer_.peek_token()->kind() == token_t::kind_e::s_eof) {
         diagnostics_.emplace_back("Unexpected end of input");
         has_error_ = true;
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
     // Check for our highest precedence primary expression.
@@ -420,42 +455,44 @@ auto parser_t::primary_expr() -> expr::expr_t
                                     token_t::kind_e::l_char,
                                     token_t::kind_e::k_true,
                                     token_t::kind_e::k_false>()) {
-        return expr::literal_t{*literal};
+        return expr::expr_t{literal->span(), expr::literal_t{*literal}};
     }
     if (auto identifier = expect_token<token_t::kind_e::k_identifier>()) {
-        return expr::identifier_t(*identifier);
+        return expr::expr_t{identifier->span(), expr::identifier_t(*identifier)};
     }
-    if (expect_token<token_t::kind_e::p_left_square>()) {
-        return array_expr();
+    if (auto left_square = expect_token<token_t::kind_e::p_left_square>(); left_square) {
+        return array_expr(*left_square);
     }
-    if (expect_token<token_t::kind_e::p_left_brace>()) {
-        return record_expr();
+    if (auto left_brace = expect_token<token_t::kind_e::p_left_brace>(); left_brace) {
+        return record_expr(*left_brace);
     }
-    if (expect_token<token_t::kind_e::p_left_paren>()) {
-        return tuple_or_grouping_expr();
+    if (auto left_paren = expect_token<token_t::kind_e::p_left_paren>(); left_paren) {
+        return tuple_or_grouping_expr(*left_paren);
     }
 
     diagnostics_.emplace_back("Unexpected token: " + std::string(lexer_.peek_token()->span()));
     has_error_ = true;
-    return expr::error_t{};
+    return expr::expr_t{"", expr::error_t{}};
 }
 
-auto parser_t::array_expr() -> expr::expr_t
+auto parser_t::array_expr(const token_t& left_square) -> expr::expr_t
 {
     auto elements = parse_delimited<token_t::kind_e::p_right_square, token_t::kind_e::p_comma, expr::expr_t>(
         [this]() -> expr::expr_t { return parse_expr_internal(); });
 
     // Expect the closing square bracket.
-    if (!expect_token<token_t::kind_e::p_right_square>()) {
+    auto right_square = expect_token<token_t::kind_e::p_right_square>();
+    if (!right_square) {
         diagnostics_.emplace_back("Expected ']' after array elements");
         has_error_ = true;
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
-    return expr::array_t{std::move(elements)};
+    const node_base_t span{left_square.span().begin(), right_square->span().end()};
+    return expr::expr_t{span, expr::array_t{std::move(elements)}};
 }
 
-auto parser_t::record_expr() -> expr::expr_t
+auto parser_t::record_expr(const token_t& left_brace) -> expr::expr_t
 {
     auto elements = parse_delimited<token_t::kind_e::p_right_brace, token_t::kind_e::p_comma, expr::record_t::field_t>(
         [this]() -> expr::record_t::field_t {
@@ -464,48 +501,53 @@ auto parser_t::record_expr() -> expr::expr_t
             if (!name) {
                 diagnostics_.emplace_back("Expected identifier for record field name");
                 has_error_ = true;
-                return expr::record_t::field_t{.name = token_t::k_identifier("<error>"), .value = expr::error_t{}};
+                return expr::record_t::field_t{.name  = token_t::k_identifier("<error>"),
+                                               .value = expr::expr_t{"", expr::error_t{}}};
             }
 
             if (!expect_token<token_t::kind_e::p_colon>()) {
                 diagnostics_.emplace_back("Expected ':' after record field name");
                 has_error_ = true;
-                return expr::record_t::field_t{.name = *name, .value = expr::error_t{}};
+                return expr::record_t::field_t{.name = *name, .value = expr::expr_t{"", expr::error_t{}}};
             }
 
             return expr::record_t::field_t{.name = *name, .value = parse_expr_internal()};
         });
 
     // Expect the closing brace.
-    if (!expect_token<token_t::kind_e::p_right_brace>()) {
+    auto right_brace = expect_token<token_t::kind_e::p_right_brace>();
+    if (!right_brace) {
         diagnostics_.emplace_back("Expected '}' after record fields");
         has_error_ = true;
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
-    return expr::record_t{std::move(elements)};
+    const node_base_t span{left_brace.span().begin(), right_brace->span().end()};
+    return expr::expr_t{span, expr::record_t{std::move(elements)}};
 }
 
-auto parser_t::tuple_or_grouping_expr() -> expr::expr_t
+auto parser_t::tuple_or_grouping_expr(const token_t& left_paren) -> expr::expr_t
 {
     // Special case for empty tuple
-    if (expect_token<token_t::kind_e::p_right_paren>()) {
-        return expr::tuple_t{{}};
+    if (auto right_paren = expect_token<token_t::kind_e::p_right_paren>(); right_paren) {
+        const node_base_t span{left_paren.span().begin(), right_paren->span().end()};
+        return expr::expr_t{span, expr::tuple_t{{}}};
     }
 
     // The first expression, This is either the expression of a grouping or the first element of a tuple.
     auto first_expr = parse_expr_internal();
 
     // If we have a single element followed by a paren then its a grouping, otherwise we have some kind of tuple
-    if (expect_token<token_t::kind_e::p_right_paren>()) {
-        return expr::grouping_t{safe_ptr<expr::expr_t>::make(std::move(first_expr))};
+    if (auto right_paren = expect_token<token_t::kind_e::p_right_paren>(); right_paren) {
+        const node_base_t span{left_paren.span().begin(), right_paren->span().end()};
+        return expr::expr_t{span, expr::grouping_t{safe_ptr<expr::expr_t>::make(std::move(first_expr))}};
     }
 
     // We must have a comma after the first expression to indicate a tuple.
     if (!expect_token<token_t::kind_e::p_comma>()) {
         diagnostics_.emplace_back("Expected ',' or ')' after expression");
         has_error_ = true;
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
     // Now parse the rest of tuple elements, constructing the vector with the first element.
@@ -514,13 +556,15 @@ auto parser_t::tuple_or_grouping_expr() -> expr::expr_t
             std::move(first_expr), [this]() -> expr::expr_t { return parse_expr_internal(); });
 
     // Expect the closing paren.
-    if (!expect_token<token_t::kind_e::p_right_paren>()) {
+    auto right_paren = expect_token<token_t::kind_e::p_right_paren>();
+    if (!right_paren) {
         diagnostics_.emplace_back("Expected ')' after expression");
         has_error_ = true;
-        return expr::error_t{};
+        return expr::expr_t{"", expr::error_t{}};
     }
 
-    return expr::tuple_t{std::move(elements)};
+    const node_base_t span{left_paren.span().begin(), right_paren->span().end()};
+    return expr::expr_t{span, expr::tuple_t{std::move(elements)}};
 }
 
 } // namespace loxmocha::internal

--- a/src/parser/parser-internal.hpp
+++ b/src/parser/parser-internal.hpp
@@ -6,6 +6,7 @@
 #include "loxmocha/ast/parser.hpp"
 #include "loxmocha/ast/pattern.hpp"
 #include "loxmocha/ast/stmt.hpp"
+#include "loxmocha/ast/token.hpp"
 
 #include <utility>
 #include <vector>
@@ -170,19 +171,18 @@ private:
 
     static auto is_decl_start_token(const token_t& token) -> bool;
 
-    auto fun_decl() -> decl::decl_t;
-    auto item_decl(decl::variable_t::mut_e mut) -> decl::decl_t;
-    auto type_decl() -> decl::decl_t;
+    auto fun_decl(token_t fun) -> decl::decl_t;
+    auto item_decl(const token_t& let, decl::variable_t::mut_e mut) -> decl::decl_t;
+    auto type_decl(token_t type) -> decl::decl_t;
 
-    auto if_expr() -> expr::expr_t;
-    auto if_body() -> expr::expr_t;
+    auto if_expr(token_t if_tok) -> expr::expr_t;
     auto else_body() -> expr::expr_t;
     auto conditional_branch() -> expr::if_t::conditional_branch_t;
 
-    auto while_expr() -> expr::expr_t;
+    auto while_expr(token_t while_tok) -> expr::expr_t;
 
-    auto block_expr() -> expr::expr_t;
-    auto block_body() -> expr::expr_t;
+    auto block_expr(token_t begin) -> expr::expr_t;
+    auto block_body(token_t begin) -> expr::expr_t;
 
     auto or_expr() -> expr::expr_t;
     auto and_expr() -> expr::expr_t;
@@ -200,9 +200,9 @@ private:
     auto call_expr(expr::expr_t&& callee_expr) -> expr::expr_t;
     auto access_expr() -> expr::expr_t;
     auto primary_expr() -> expr::expr_t;
-    auto array_expr() -> expr::expr_t;
-    auto record_expr() -> expr::expr_t;
-    auto tuple_or_grouping_expr() -> expr::expr_t;
+    auto array_expr(const token_t& left_square) -> expr::expr_t;
+    auto record_expr(const token_t& left_brace) -> expr::expr_t;
+    auto tuple_or_grouping_expr(const token_t& left_paren) -> expr::expr_t;
 
     auto tag_pattern() -> pattern::pattern_t;
     auto primary_pattern() -> pattern::pattern_t;
@@ -210,14 +210,14 @@ private:
     auto expr_or_assign_stmt() -> stmt::stmt_t;
     auto decl_stmt() -> stmt::stmt_t;
 
-    auto fun_type() -> type::type_t;
-    auto ref_type() -> type::type_t;
-    auto mutable_type() -> type::type_t;
-    auto tagged_type() -> type::type_t;
-    auto record_type() -> type::type_t;
+    auto fun_type(const token_t& fun) -> type::type_t;
+    auto ref_type(const token_t& let) -> type::type_t;
+    auto mutable_type(const token_t& var) -> type::type_t;
+    auto tagged_type(const token_t& choice) -> type::type_t;
+    auto record_type(const token_t& rec) -> type::type_t;
     auto array_type() -> type::type_t;
     auto primary_type() -> type::type_t;
-    auto tuple_or_grouping_type() -> type::type_t;
+    auto tuple_or_grouping_type(const token_t& left_paren) -> type::type_t;
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     lexer_t&                 lexer_;

--- a/src/source/CMakeLists.txt
+++ b/src/source/CMakeLists.txt
@@ -1,0 +1,8 @@
+loxmocha_add_library(source
+    source.cpp
+)
+
+target_link_libraries(loxmocha_source
+    PUBLIC
+    loxmocha::memory
+)

--- a/src/source/include/loxmocha/source/source.hpp
+++ b/src/source/include/loxmocha/source/source.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "loxmocha/memory/safe_pointer.hpp"
+
+#include <cstddef>
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace loxmocha::source {
+
+struct source_location_t {
+    std::string_view line_span;
+    std::size_t      line;
+    std::size_t      column;
+};
+
+struct span_less_t {
+    auto operator()(const std::string_view& lhs, const std::string_view& rhs) const -> bool
+    {
+        return lhs.data() < rhs.data();
+    }
+};
+
+class source_info_t {
+public:
+    source_info_t(std::filesystem::path filepath, std::string&& content);
+    source_info_t() = delete;
+
+    [[nodiscard]] auto filepath() const -> const std::filesystem::path& { return filepath_; }
+    [[nodiscard]] auto content() const -> std::string_view { return content_; }
+    [[nodiscard]] auto lines() const -> std::span<const std::string_view> { return lines_; }
+    [[nodiscard]] auto find_location(std::string_view source_span) const -> std::optional<source_location_t>;
+
+private:
+    std::filesystem::path         filepath_;
+    std::string                   content_;
+    std::vector<std::string_view> lines_;
+};
+
+class source_view_t {
+public:
+    source_view_t(std::filesystem::path filepath, std::string_view content, std::span<const std::string_view> lines)
+        : filepath_(std::move(filepath)), content_(content), lines_(lines)
+    {
+    }
+
+    [[nodiscard]] auto filepath() const -> const std::filesystem::path& { return filepath_; }
+    [[nodiscard]] auto content() const -> std::string_view { return content_; }
+    [[nodiscard]] auto lines() const -> std::span<const std::string_view> { return lines_; }
+    [[nodiscard]] auto find_location(std::string_view source_span) const -> std::optional<source_location_t>;
+
+private:
+    std::filesystem::path             filepath_;
+    std::string_view                  content_;
+    std::span<const std::string_view> lines_;
+};
+
+class source_manager_t {
+public:
+    class iterator_t {
+    public:
+        auto operator++() -> iterator_t&
+        {
+            ++internal_iterator_;
+            return *this;
+        }
+
+        [[nodiscard]] auto operator*() const -> source_view_t { return this->view(); }
+        [[nodiscard]] auto operator->() const -> source_view_t { return this->view(); }
+        [[nodiscard]] auto operator==(const iterator_t& other) const -> bool
+        {
+            return internal_iterator_ == other.internal_iterator_;
+        }
+
+        [[nodiscard]] auto operator!=(const iterator_t& other) const -> bool { return !(*this == other); }
+
+        [[nodiscard]] auto view() const -> source_view_t
+        {
+            return source_view_t{internal_iterator_->second->filepath(),
+                                 internal_iterator_->second->content(),
+                                 internal_iterator_->second->lines()};
+        }
+
+    private:
+        friend class source_manager_t;
+        explicit iterator_t(std::unordered_map<std::filesystem::path, safe_ptr<source_info_t>>::const_iterator iter)
+            : internal_iterator_(iter)
+        {
+        }
+        std::unordered_map<std::filesystem::path, safe_ptr<source_info_t>>::const_iterator internal_iterator_;
+    };
+
+    source_manager_t() = default;
+
+    source_manager_t(const source_manager_t&)     = delete;
+    source_manager_t(source_manager_t&&) noexcept = default;
+    ~source_manager_t()                           = default;
+
+    auto operator=(const source_manager_t&) -> source_manager_t&     = delete;
+    auto operator=(source_manager_t&&) noexcept -> source_manager_t& = default;
+
+    auto emplace(safe_ptr<source_info_t>&& source_info) -> std::pair<iterator_t, bool>;
+
+    [[nodiscard]] auto find_source(std::string_view source_span) const -> iterator_t;
+    [[nodiscard]] auto find_source(const std::filesystem::path& filepath) const -> iterator_t;
+
+    [[nodiscard]] auto begin() -> iterator_t;
+    [[nodiscard]] auto end() -> iterator_t;
+
+private:
+    std::unordered_map<std::filesystem::path, safe_ptr<source_info_t>> filepath_map_;
+    std::map<std::string_view, source_info_t&, span_less_t>            source_map_;
+};
+
+} // namespace loxmocha::source

--- a/src/source/include/loxmocha/source/source.hpp
+++ b/src/source/include/loxmocha/source/source.hpp
@@ -159,7 +159,7 @@ class source_manager_t {
 public:
     /**
      * @class iterator_t
-     * @brief Iterator into the source files manages by source_manager_t.
+     * @brief Iterator into the source files managed by source_manager_t.
      * This iterator provides an access to source_view_t for the source file it points to.
      */
     class iterator_t {

--- a/src/source/include/loxmocha/source/source.hpp
+++ b/src/source/include/loxmocha/source/source.hpp
@@ -20,22 +20,59 @@ struct source_location_t {
     std::size_t      column;
 };
 
-struct span_less_t {
-    auto operator()(const std::string_view& lhs, const std::string_view& rhs) const -> bool
-    {
-        return lhs.data() < rhs.data();
-    }
-};
-
+/**
+ * @class source_info_t
+ * @brief Represents information about a source file, including its path, content, and line mappings.
+ * This class is responsible for owning the source content and providing ways to map pointers in the content to source
+ * locations.
+ */
 class source_info_t {
 public:
+    /**
+     * @brief Constructs a source_info_t with the given file path and content.
+     * @param filepath The file path of the source file.
+     * @param content The content of the source file. The content is moved into the source_info_t.
+     */
     source_info_t(std::filesystem::path filepath, std::string&& content);
     source_info_t() = delete;
 
+    source_info_t(const source_info_t&)     = delete;
+    source_info_t(source_info_t&&) noexcept = default;
+    ~source_info_t()                        = default;
+
+    auto operator=(const source_info_t&) -> source_info_t&     = delete;
+    auto operator=(source_info_t&&) noexcept -> source_info_t& = default;
+
+    /**
+     * @brief Get the file path of the source file.
+     * @return const std::filesystem::path& The file path of the source file.
+     */
     [[nodiscard]] auto filepath() const -> const std::filesystem::path& { return filepath_; }
+
+    /**
+     * @brief Get the content of the source file.
+     * @return std::string_view The content of the source file.
+     */
     [[nodiscard]] auto content() const -> std::string_view { return content_; }
+
+    /** @brief Get the lines of the source file.
+     * @return std::span<const std::string_view> The lines of the source file.
+     */
     [[nodiscard]] auto lines() const -> std::span<const std::string_view> { return lines_; }
+
+    /**
+     * @brief Find the source location corresponding to a position in the source content.
+     * @param pos An iterator pointing to a position in the source content.
+     * @return std::optional<source_location_t> The source location if found, or std::nullopt if not found.
+     */
     [[nodiscard]] auto find_location(std::string_view::iterator pos) const -> std::optional<source_location_t>;
+
+    /**
+     * @brief Find the source locations corresponding to a span in the source content.
+     * @param source_span A string view representing a span in the source content.
+     * @return std::optional<std::pair<source_location_t, source_location_t>> A pair of source locations representing
+     * the start and end of the span if found, or std::nullopt if not found.
+     */
     [[nodiscard]] auto find_span_location(std::string_view source_span) const
         -> std::optional<std::pair<source_location_t, source_location_t>>;
 
@@ -45,17 +82,64 @@ private:
     std::vector<std::string_view> lines_;
 };
 
+/**
+ * @class source_view_t
+ * @brief Represents a view into a source file, providing access to its path, content, and line mappings.
+ * This class does not own the source content, instead the content is owned by a source_info_t.
+ * This provides the same mapping functionality as source_info_t.
+ * Iteration order of source files is not guaranteed to be in any particular order.
+ */
 class source_view_t {
 public:
+    /**
+     * @brief Constructs a source_view_t with the given file path, content, and line mappings.
+     * @param filepath The file path of the source file.
+     * @param content The content of the source file.
+     * @param lines The line mappings of the source file.
+     */
     source_view_t(std::filesystem::path filepath, std::string_view content, std::span<const std::string_view> lines)
         : filepath_(std::move(filepath)), content_(content), lines_(lines)
     {
     }
 
+    source_view_t()                                            = delete;
+    source_view_t(const source_view_t&)                        = default;
+    source_view_t(source_view_t&&) noexcept                    = default;
+    ~source_view_t()                                           = default;
+    auto operator=(const source_view_t&) -> source_view_t&     = default;
+    auto operator=(source_view_t&&) noexcept -> source_view_t& = default;
+
+    /**
+     * @brief Get the file path of the source file.
+     * @return const std::filesystem::path& The file path of the source file.
+     */
     [[nodiscard]] auto filepath() const -> const std::filesystem::path& { return filepath_; }
+
+    /**
+     * @brief Get the content of the source file.
+     * @return std::string_view The content of the source file.
+     */
     [[nodiscard]] auto content() const -> std::string_view { return content_; }
+
+    /**
+     * @brief Get the lines of the source file.
+     * @return std::span<const std::string_view> The lines of the source file.
+     */
     [[nodiscard]] auto lines() const -> std::span<const std::string_view> { return lines_; }
+
+    /**
+     * @brief Find the source location corresponding to a position in the source content.
+     * @param pos An iterator pointing to a position in the source content.
+     * @return std::optional<source_location_t> The source location if found, or std::nullopt if not found.
+     */
     [[nodiscard]] auto find_location(std::string_view::iterator pos) const -> std::optional<source_location_t>;
+    
+    /**
+     * @brief Find the source locations corresponding to a span in the source content.
+     * @param source_span A string view representing a span in the source content.
+     * @return std::optional<std::pair<source_location_t, source_location_t>> A pair of source locations representing
+     * the start and end of the span if found, or std::nullopt if not found.
+     */
     [[nodiscard]] auto find_span_location(std::string_view source_span) const
         -> std::optional<std::pair<source_location_t, source_location_t>>;
 
@@ -65,8 +149,19 @@ private:
     std::span<const std::string_view> lines_;
 };
 
+/**
+ * @class source_manager_t
+ * @brief Manages source files and provides access to views of those source files.
+ * This class owns the source_info_t that represent and own the source content.
+ * This allows retrieval of source views by either file path, or by a span within the source content.
+ */
 class source_manager_t {
 public:
+    /**
+     * @class iterator_t
+     * @brief Iterator into the source files manages by source_manager_t.
+     * This iterator provides an access to source_view_t for the source file it points to.
+     */
     class iterator_t {
     public:
         auto operator++() -> iterator_t&
@@ -109,15 +204,46 @@ public:
     auto operator=(const source_manager_t&) -> source_manager_t&     = delete;
     auto operator=(source_manager_t&&) noexcept -> source_manager_t& = default;
 
+    /**
+     * @brief Emplaces a new source file into the source manager.
+     * @param source_info The source_info_t owning the source content to emplace.
+     * @return std::pair<iterator_t, bool> A pair containing the iterator the emplaced source file, and bool indicating
+     * if the source file was emplaced or if it already existed. If the source file already existed, the iterator points
+     * to the existing source file and the new source file was not emplaced.
+     * */
     auto emplace(safe_ptr<source_info_t>&& source_info) -> std::pair<iterator_t, bool>;
 
+    /**
+     * @brief Finds a source file by a span within its content.
+     * @param source_span The span within the source content to find the source file for.
+     * @return iterator_t An iterator to the found source file, or end if not found.
+     */
     [[nodiscard]] auto find_source(std::string_view source_span) const -> iterator_t;
+    /**
+     * @brief Finds a source file by its file path.
+     * @param filepath The file path of the source file to find.
+     * @return iterator_t An iterator to the found source file, or end if not found.
+     */
     [[nodiscard]] auto find_source(const std::filesystem::path& filepath) const -> iterator_t;
 
+    /**
+     * @brief Gets an iterator to the beginning of the source files.
+     * @return iterator_t An iterator to the beginning of the source files.
+     */
     [[nodiscard]] auto begin() const -> iterator_t;
+    /**
+     * @brief Gets an iterator to the end of the source files.
+     * @return iterator_t An iterator to the end of the source files.
+     */
     [[nodiscard]] auto end() const -> iterator_t;
 
 private:
+    struct span_less_t {
+        auto operator()(const std::string_view& lhs, const std::string_view& rhs) const -> bool
+        {
+            return lhs.data() < rhs.data();
+        }
+    };
     std::unordered_map<std::filesystem::path, safe_ptr<source_info_t>> filepath_map_;
     std::map<std::string_view, source_info_t&, span_less_t>            source_map_;
 };

--- a/src/source/include/loxmocha/source/source.hpp
+++ b/src/source/include/loxmocha/source/source.hpp
@@ -35,7 +35,9 @@ public:
     [[nodiscard]] auto filepath() const -> const std::filesystem::path& { return filepath_; }
     [[nodiscard]] auto content() const -> std::string_view { return content_; }
     [[nodiscard]] auto lines() const -> std::span<const std::string_view> { return lines_; }
-    [[nodiscard]] auto find_location(std::string_view source_span) const -> std::optional<source_location_t>;
+    [[nodiscard]] auto find_location(std::string_view::iterator pos) const -> std::optional<source_location_t>;
+    [[nodiscard]] auto find_span_location(std::string_view source_span) const
+        -> std::optional<std::pair<source_location_t, source_location_t>>;
 
 private:
     std::filesystem::path         filepath_;
@@ -53,7 +55,9 @@ public:
     [[nodiscard]] auto filepath() const -> const std::filesystem::path& { return filepath_; }
     [[nodiscard]] auto content() const -> std::string_view { return content_; }
     [[nodiscard]] auto lines() const -> std::span<const std::string_view> { return lines_; }
-    [[nodiscard]] auto find_location(std::string_view source_span) const -> std::optional<source_location_t>;
+    [[nodiscard]] auto find_location(std::string_view::iterator pos) const -> std::optional<source_location_t>;
+    [[nodiscard]] auto find_span_location(std::string_view source_span) const
+        -> std::optional<std::pair<source_location_t, source_location_t>>;
 
 private:
     std::filesystem::path             filepath_;
@@ -110,8 +114,8 @@ public:
     [[nodiscard]] auto find_source(std::string_view source_span) const -> iterator_t;
     [[nodiscard]] auto find_source(const std::filesystem::path& filepath) const -> iterator_t;
 
-    [[nodiscard]] auto begin() -> iterator_t;
-    [[nodiscard]] auto end() -> iterator_t;
+    [[nodiscard]] auto begin() const -> iterator_t;
+    [[nodiscard]] auto end() const -> iterator_t;
 
 private:
     std::unordered_map<std::filesystem::path, safe_ptr<source_info_t>> filepath_map_;

--- a/src/source/include/loxmocha/source/source.hpp
+++ b/src/source/include/loxmocha/source/source.hpp
@@ -133,7 +133,7 @@ public:
      * @return std::optional<source_location_t> The source location if found, or std::nullopt if not found.
      */
     [[nodiscard]] auto find_location(std::string_view::iterator pos) const -> std::optional<source_location_t>;
-    
+
     /**
      * @brief Find the source locations corresponding to a span in the source content.
      * @param source_span A string view representing a span in the source content.

--- a/src/source/source.cpp
+++ b/src/source/source.cpp
@@ -57,12 +57,14 @@ auto source_info_t::find_span_location(std::string_view source_span) const
 auto source_view_t::find_location(std::string_view::iterator pos) const -> std::optional<source_location_t>
 {
     // Find the the first line start position that is before input position.
-    auto line = std::ranges::lower_bound(
-        lines_.begin(), lines_.end(), pos, [](const std::string_view& line, const std::string_view& span) -> bool {
-            // Here we true if the line is before the span
-            // cppcheck-suppress mismatchingContainerExpression
-            return line.end() <= span.begin();
-        });
+    auto line = std::ranges::lower_bound(lines_.begin(),
+                                         lines_.end(),
+                                         std::string_view{pos, std::next(pos)},
+                                         [](const std::string_view& line, const std::string_view& span) -> bool {
+                                             // Here we return true if the line is before the span
+                                             // cppcheck-suppress mismatchingContainerExpression
+                                             return line.end() <= span.begin();
+                                         });
 
     // If we do not have lower bound then the position is not in the source.
     if (line == lines_.end()) {

--- a/src/source/source.cpp
+++ b/src/source/source.cpp
@@ -1,0 +1,113 @@
+#include "loxmocha/source/source.hpp"
+
+#include "loxmocha/memory/safe_pointer.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <filesystem>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace loxmocha::source {
+
+namespace {
+    auto make_lines(std::string_view content) -> std::vector<std::string_view>
+    {
+        std::vector<std::string_view> lines{};
+        const auto*                   line_start = content.begin();
+        for (const auto* iter = content.begin(); iter != content.end(); std::advance(iter, 1)) {
+            if (*iter == '\n') {
+                lines.emplace_back(line_start, iter);
+                line_start = std::next(iter);
+            }
+        }
+        if (line_start != content.end()) {
+            lines.emplace_back(line_start, content.end());
+        }
+
+        return lines;
+    }
+} // namespace
+
+source_info_t::source_info_t(std::filesystem::path filepath, std::string&& content)
+    : filepath_(std::move(filepath)), content_(std::move(content)), lines_(make_lines(content_))
+{
+}
+
+auto source_info_t::find_location(std::string_view source_span) const -> std::optional<source_location_t>
+{
+    return source_view_t{filepath_, content_, lines_}.find_location(source_span);
+}
+
+auto source_view_t::find_location(std::string_view source_span) const -> std::optional<source_location_t>
+{
+    auto line = std::ranges::lower_bound(lines_.begin(),
+                                         lines_.end(),
+                                         source_span,
+                                         [](const std::string_view& line, const std::string_view& span) -> bool {
+                                             // cppcheck-suppress mismatchingContainerExpression
+                                             return line.end() <= span.begin();
+                                         });
+
+    if (line == lines_.end()) {
+        return std::nullopt;
+    }
+
+    return source_location_t{
+        .line_span = *line,
+        .line      = static_cast<std::size_t>(std::distance(lines_.begin(), line) + 1),
+        .column    = static_cast<std::size_t>(source_span.data() - line->data() + 1),
+    };
+}
+
+auto source_manager_t::emplace(safe_ptr<source_info_t>&& source_info) -> std::pair<iterator_t, bool>
+{
+    auto result = filepath_map_.emplace(source_info->filepath(), std::move(source_info));
+
+    if (result.second) {
+        source_map_.emplace(result.first->second->content(), *(result.first->second));
+    }
+
+    return {iterator_t{result.first}, result.second};
+}
+
+auto source_manager_t::find_source(const std::filesystem::path& filepath) const -> source_manager_t::iterator_t
+{
+    auto iter = filepath_map_.find(filepath);
+    if (iter == filepath_map_.end()) {
+        return source_manager_t::iterator_t{filepath_map_.end()};
+    }
+
+    return source_manager_t::iterator_t{iter};
+}
+
+auto source_manager_t::find_source(std::string_view source_span) const -> source_manager_t::iterator_t
+{
+    auto upper = source_map_.upper_bound(source_span);
+    if (upper == source_map_.begin()) {
+        return source_manager_t::iterator_t{filepath_map_.end()};
+    }
+
+    auto iter = std::prev(upper);
+    if (iter->first.begin() <= source_span.begin() && source_span.end() <= iter->first.end()) {
+        return source_manager_t::iterator_t{filepath_map_.find(iter->second.filepath())};
+    }
+
+    return source_manager_t::iterator_t{filepath_map_.end()};
+}
+
+auto source_manager_t::begin() -> source_manager_t::iterator_t
+{
+    return source_manager_t::iterator_t{filepath_map_.begin()};
+}
+
+auto source_manager_t::end() -> source_manager_t::iterator_t
+{
+    return source_manager_t::iterator_t{filepath_map_.end()};
+}
+
+} // namespace loxmocha::source

--- a/test/parser/assert_visitor.hpp
+++ b/test/parser/assert_visitor.hpp
@@ -164,7 +164,7 @@ public:
             EXPECT_EQ(a_param.name.kind(), loxmocha::token_t::kind_e::k_identifier);
             EXPECT_EQ(a_param.name.kind(), e_param.name.kind());
             EXPECT_EQ(a_param.name.span(), e_param.name.span());
-            a_param.type->visit(*this, *e_param.type);
+            a_param.type.visit(*this, e_param.type);
         }
 
         // Make sure the return types and bodies are the same.
@@ -408,8 +408,8 @@ public:
         // Make sure each of the branches of the if match
         for (const auto& [a_branch, e_branch] :
              std::views::zip(actual.conditional_branches(), expected.conditional_branches())) {
-            a_branch.condition->visit(*this, *e_branch.condition);
-            a_branch.then_branch->visit(*this, *e_branch.then_branch);
+            a_branch.condition.visit(*this, e_branch.condition);
+            a_branch.then_branch.visit(*this, e_branch.then_branch);
         }
 
         // If both actual and expected have else branches then compare them

--- a/test/parser/assert_visitor.hpp
+++ b/test/parser/assert_visitor.hpp
@@ -62,6 +62,11 @@ public:
                << demangle(typeid(expected).name()) << " got type: " << demangle(typeid(actual).name());
     }
 
+    void operator()([[maybe_unused]] const loxmocha::node_base_t& base, const auto& actual, const auto& expected)
+    {
+        this->operator()(actual, expected);
+    }
+
     /**
      * @brief Unwraps the expected node and then calls back into the visitor with the actual and expected nodes.
      *
@@ -70,10 +75,10 @@ public:
      */
     void operator()(const auto& actual, const loxmocha::decl::decl_t& expected)
     {
-        // Unwrap the expected declaration and visit again
-        expected.visit(
-            [&visitor = *this](const auto& expected, const auto& actual) -> void { visitor(actual, expected); },
-            actual);
+        expected.visit([&visitor = *this]([[maybe_unused]] const node_base_t& base,
+                                          const auto&                         expected,
+                                          const auto& actual) -> void { visitor(actual, expected); },
+                       actual);
     }
 
     /**
@@ -84,9 +89,10 @@ public:
      */
     void operator()(const auto& actual, const loxmocha::expr::expr_t& expected)
     {
-        expected.visit(
-            [&visitor = *this](const auto& expected, const auto& actual) -> void { visitor(actual, expected); },
-            actual);
+        expected.visit([&visitor = *this]([[maybe_unused]] const node_base_t& base,
+                                          const auto&                         expected,
+                                          const auto& actual) -> void { visitor(actual, expected); },
+                       actual);
     }
 
     /**
@@ -97,9 +103,10 @@ public:
      */
     void operator()(const auto& actual, const loxmocha::pattern::pattern_t& expected)
     {
-        expected.visit(
-            [&visitor = *this](const auto& expected, const auto& actual) -> void { visitor(actual, expected); },
-            actual);
+        expected.visit([&visitor = *this]([[maybe_unused]] const node_base_t& base,
+                                          const auto&                         expected,
+                                          const auto& actual) -> void { visitor(actual, expected); },
+                       actual);
     }
 
     /**
@@ -110,9 +117,10 @@ public:
      */
     void operator()(const auto& actual, const loxmocha::stmt::stmt_t& expected)
     {
-        expected.visit(
-            [&visitor = *this](const auto& expected, const auto& actual) -> void { visitor(actual, expected); },
-            actual);
+        expected.visit([&visitor = *this]([[maybe_unused]] const node_base_t& base,
+                                          const auto&                         expected,
+                                          const auto& actual) -> void { visitor(actual, expected); },
+                       actual);
     }
 
     /**
@@ -123,9 +131,10 @@ public:
      */
     void operator()(const auto& actual, const loxmocha::type::type_t& expected)
     {
-        expected.visit(
-            [&visitor = *this](const auto& expected, const auto& actual) -> void { visitor(actual, expected); },
-            actual);
+        expected.visit([&visitor = *this]([[maybe_unused]] const node_base_t& base,
+                                          const auto&                         expected,
+                                          const auto& actual) -> void { visitor(actual, expected); },
+                       actual);
     }
 
     /**

--- a/test/parser/helpers.hpp
+++ b/test/parser/helpers.hpp
@@ -14,29 +14,34 @@
 
 namespace loxmocha::test::helpers {
 
-[[nodiscard]] inline auto d(loxmocha::decl::decl_t&& decl) -> loxmocha::safe_ptr<loxmocha::decl::decl_t>
+template<typename... Args>
+[[nodiscard]] inline auto d(Args&&... decl) -> loxmocha::safe_ptr<loxmocha::decl::decl_t>
 {
-    return loxmocha::safe_ptr<loxmocha::decl::decl_t>::make(std::move(decl));
+    return loxmocha::safe_ptr<loxmocha::decl::decl_t>::make("", std::forward<Args>(decl)...);
 }
 
-[[nodiscard]] inline auto e(loxmocha::expr::expr_t&& expr) -> loxmocha::safe_ptr<loxmocha::expr::expr_t>
+template<typename... Args>
+[[nodiscard]] inline auto e(Args&&... expr) -> loxmocha::safe_ptr<loxmocha::expr::expr_t>
 {
-    return loxmocha::safe_ptr<loxmocha::expr::expr_t>::make(std::move(expr));
+    return loxmocha::safe_ptr<loxmocha::expr::expr_t>::make("", std::forward<Args>(expr)...);
 }
 
-[[nodiscard]] inline auto p(loxmocha::pattern::pattern_t&& pattern) -> loxmocha::safe_ptr<loxmocha::pattern::pattern_t>
+template<typename... Args>
+[[nodiscard]] inline auto p(Args&&... pattern) -> loxmocha::safe_ptr<loxmocha::pattern::pattern_t>
 {
-    return loxmocha::safe_ptr<loxmocha::pattern::pattern_t>::make(std::move(pattern));
+    return loxmocha::safe_ptr<loxmocha::pattern::pattern_t>::make("", std::forward<Args>(pattern)...);
 }
 
-[[nodiscard]] inline auto s(loxmocha::stmt::stmt_t&& stmt) -> loxmocha::safe_ptr<loxmocha::stmt::stmt_t>
+template<typename... Args>
+[[nodiscard]] inline auto s(Args&&... stmt) -> loxmocha::safe_ptr<loxmocha::stmt::stmt_t>
 {
-    return loxmocha::safe_ptr<loxmocha::stmt::stmt_t>::make(std::move(stmt));
+    return loxmocha::safe_ptr<loxmocha::stmt::stmt_t>::make("", std::forward<Args>(stmt)...);
 }
 
-[[nodiscard]] inline auto t(loxmocha::type::type_t&& type) -> loxmocha::safe_ptr<loxmocha::type::type_t>
+template<typename... Args>
+[[nodiscard]] inline auto t(Args&&... args) -> loxmocha::safe_ptr<loxmocha::type::type_t>
 {
-    return loxmocha::safe_ptr<loxmocha::type::type_t>::make(std::move(type));
+    return loxmocha::safe_ptr<loxmocha::type::type_t>::make("", std::forward<Args>(args)...);
 }
 
 template<typename T, typename... Args>
@@ -44,12 +49,20 @@ auto make_vector(Args&&... args) -> std::vector<T>
 {
     std::vector<T> vec;
     vec.reserve(sizeof...(Args));
+    (vec.emplace_back("", std::forward<Args>(args)), ...);
+    return vec;
+}
+
+template<typename T, typename... Args>
+auto make_vector2(Args&&... args) -> std::vector<T>
+{
+    std::vector<T> vec;
+    vec.reserve(sizeof...(Args));
     (vec.emplace_back(std::forward<Args>(args)), ...);
     return vec;
 }
 
-template<typename T>
-void base_test(const std::string& source, const T& expected, auto&& parse)
+void base_test(const std::string& source, const auto& expected, auto&& parse)
 {
     // NOLINTNEXTLINE(misc-const-correctness)
     lexer_t lexer{source};
@@ -64,25 +77,13 @@ void base_test(const std::string& source, const T& expected, auto&& parse)
     result.result().visit(assert_visitor{}, expected);
 }
 
-inline void decl_test(const std::string& source, const decl::decl_t& expected)
-{
-    base_test<decl::decl_t>(source, expected, parse_decl);
-}
+inline void decl_test(const std::string& source, const auto& expected) { base_test(source, expected, parse_decl); }
 
-inline void expr_test(const std::string& source, const expr::expr_t& expected)
-{
-    base_test<expr::expr_t>(source, expected, parse_expr);
-}
+inline void expr_test(const std::string& source, const auto& expected) { base_test(source, expected, parse_expr); }
 
-inline void stmt_test(const std::string& source, const stmt::stmt_t& expected)
-{
-    base_test<stmt::stmt_t>(source, expected, parse_stmt);
-}
+inline void stmt_test(const std::string& source, const auto& expected) { base_test(source, expected, parse_stmt); }
 
-inline void type_test(const std::string& source, const type::type_t& expected)
-{
-    base_test<type::type_t>(source, expected, parse_type);
-}
+inline void type_test(const std::string& source, const auto& expected) { base_test(source, expected, parse_type); }
 
 inline void
 rainy_day_test(const std::string& source, const std::vector<std::string>& expected_diagnostics, auto&& parse)

--- a/test/parser/parser-decl-test.cpp
+++ b/test/parser/parser-decl-test.cpp
@@ -55,7 +55,8 @@ TEST(ParserTest, DeclFunctionBlockBodyTest)
         decl::function_t{
             token_t::k_identifier("my_func"),
             make_vector2<decl::function_t::parameter_t>(decl::function_t::parameter_t{
-                .name = token_t::k_identifier("n"), .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}}),
+                .name = token_t::k_identifier("n"),
+                .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}}),
             t(type::identifier_t{token_t::k_identifier("int")}),
             e(expr::block_t{make_vector<stmt::stmt_t>(
                                 stmt::decl_t{d(decl::variable_t{decl::variable_t::mut_e::var,
@@ -87,14 +88,14 @@ TEST(ParserTest, DeclFunctionNoParametersTest)
 TEST(ParserTest, DeclFunctionNoReturnTypeTest)
 {
     decl_test("fun my_func(a: int) => print(a)",
-              decl::function_t{
-                  token_t::k_identifier("my_func"),
-                  make_vector2<decl::function_t::parameter_t>(decl::function_t::parameter_t{
-                      .name = token_t::k_identifier("a"), .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}}),
-                  t(type::tuple_t{{}}),
-                  e(expr::call_t{e(expr::identifier_t{token_t::k_identifier("print")}),
-                                 make_vector<expr::expr_t>(expr::identifier_t{token_t::k_identifier("a")}),
-                                 {}})});
+              decl::function_t{token_t::k_identifier("my_func"),
+                               make_vector2<decl::function_t::parameter_t>(decl::function_t::parameter_t{
+                                   .name = token_t::k_identifier("a"),
+                                   .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}}),
+                               t(type::tuple_t{{}}),
+                               e(expr::call_t{e(expr::identifier_t{token_t::k_identifier("print")}),
+                                              make_vector<expr::expr_t>(expr::identifier_t{token_t::k_identifier("a")}),
+                                              {}})});
 }
 
 TEST(ParserTest, DeclLetTest)

--- a/test/parser/parser-decl-test.cpp
+++ b/test/parser/parser-decl-test.cpp
@@ -22,11 +22,13 @@ TEST(ParserTest, DeclFunctionTest)
         "fun my_func(a: int, b: string): bool => to_string(a) == b",
         decl::function_t{
             token_t::k_identifier("my_func"),
-            make_vector<decl::function_t::parameter_t>(
+            make_vector2<decl::function_t::parameter_t>(
                 decl::function_t::parameter_t{.name = token_t::k_identifier("a"),
-                                              .type = t(type::identifier_t{token_t::k_identifier("int")})},
+                                              .type =
+                                                  type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}},
                 decl::function_t::parameter_t{.name = token_t::k_identifier("b"),
-                                              .type = t(type::identifier_t{token_t::k_identifier("string")})}
+                                              .type =
+                                                  type::type_t{"", type::identifier_t{token_t::k_identifier("string")}}}
 
                 ),
             t(type::identifier_t{token_t::k_identifier("bool")}),
@@ -52,8 +54,8 @@ TEST(ParserTest, DeclFunctionBlockBodyTest)
     )",
         decl::function_t{
             token_t::k_identifier("my_func"),
-            make_vector<decl::function_t::parameter_t>(decl::function_t::parameter_t{
-                .name = token_t::k_identifier("n"), .type = t(type::identifier_t{token_t::k_identifier("int")})}),
+            make_vector2<decl::function_t::parameter_t>(decl::function_t::parameter_t{
+                .name = token_t::k_identifier("n"), .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}}),
             t(type::identifier_t{token_t::k_identifier("int")}),
             e(expr::block_t{make_vector<stmt::stmt_t>(
                                 stmt::decl_t{d(decl::variable_t{decl::variable_t::mut_e::var,
@@ -87,8 +89,8 @@ TEST(ParserTest, DeclFunctionNoReturnTypeTest)
     decl_test("fun my_func(a: int) => print(a)",
               decl::function_t{
                   token_t::k_identifier("my_func"),
-                  make_vector<decl::function_t::parameter_t>(decl::function_t::parameter_t{
-                      .name = token_t::k_identifier("a"), .type = t(type::identifier_t{token_t::k_identifier("int")})}),
+                  make_vector2<decl::function_t::parameter_t>(decl::function_t::parameter_t{
+                      .name = token_t::k_identifier("a"), .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}}),
                   t(type::tuple_t{{}}),
                   e(expr::call_t{e(expr::identifier_t{token_t::k_identifier("print")}),
                                  make_vector<expr::expr_t>(expr::identifier_t{token_t::k_identifier("a")}),

--- a/test/parser/parser-expr-test.cpp
+++ b/test/parser/parser-expr-test.cpp
@@ -300,27 +300,29 @@ TEST(ParserTest, ExprCallPositionalArgumentsTest)
 
 TEST(ParserTest, ExprCallNamedArgumentsTest)
 {
-    expr_test("setPosition(x: 100, y: 200)",
-              expr::call_t{e(expr::identifier_t{token_t::k_identifier("setPosition")}),
-                           {},
-                           make_vector<expr::call_t::named_arg_t>(
-                               expr::call_t::named_arg_t{.name  = token_t::k_identifier("x"),
-                                                         .value = expr::literal_t{token_t::l_integer("100")}},
-                               expr::call_t::named_arg_t{.name  = token_t::k_identifier("y"),
-                                                         .value = expr::literal_t{token_t::l_integer("200")}})});
+    expr_test(
+        "setPosition(x: 100, y: 200)",
+        expr::call_t{
+            e(expr::identifier_t{token_t::k_identifier("setPosition")}),
+            {},
+            make_vector2<expr::call_t::named_arg_t>(
+                expr::call_t::named_arg_t{.name  = token_t::k_identifier("x"),
+                                          .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("100")}}},
+                expr::call_t::named_arg_t{.name  = token_t::k_identifier("y"),
+                                          .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("200")}}})});
 }
 
 TEST(ParserTest, ExprCallMixedArgumentTest)
 {
     expr_test("drawCircle(x + 10, y, radius: 25)",
-              expr::call_t{
-                  e(expr::identifier_t{token_t::k_identifier("drawCircle")}),
-                  make_vector<expr::expr_t>(expr::binary_t{token_t::p_plus("+"),
-                                                           e(expr::identifier_t{token_t::k_identifier("x")}),
-                                                           e(expr::literal_t{token_t::l_integer("10")})},
-                                            expr::identifier_t{token_t::k_identifier("y")}),
-                  make_vector<expr::call_t::named_arg_t>(expr::call_t::named_arg_t{
-                      .name = token_t::k_identifier("radius"), .value = expr::literal_t{token_t::l_integer("25")}})});
+              expr::call_t{e(expr::identifier_t{token_t::k_identifier("drawCircle")}),
+                           make_vector<expr::expr_t>(expr::binary_t{token_t::p_plus("+"),
+                                                                    e(expr::identifier_t{token_t::k_identifier("x")}),
+                                                                    e(expr::literal_t{token_t::l_integer("10")})},
+                                                     expr::identifier_t{token_t::k_identifier("y")}),
+                           make_vector2<expr::call_t::named_arg_t>(expr::call_t::named_arg_t{
+                               .name  = token_t::k_identifier("radius"),
+                               .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("25")}}})});
 }
 
 TEST(ParserTest, ExprPositionalAfterNamedArgsTest)
@@ -476,11 +478,11 @@ TEST(ParserTest, ExprArrayPrecedenceTest)
 TEST(ParserTest, ExprRecordTest)
 {
     expr_test("{x: 10, y: 20}",
-              expr::record_t{make_vector<expr::record_t::field_t>(
+              expr::record_t{make_vector2<expr::record_t::field_t>(
                   expr::record_t::field_t{.name  = token_t::k_identifier("x"),
-                                          .value = expr::literal_t{token_t::l_integer("10")}},
+                                          .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("10")}}},
                   expr::record_t::field_t{.name  = token_t::k_identifier("y"),
-                                          .value = expr::literal_t{token_t::l_integer("20")}})});
+                                          .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("20")}}})});
 }
 
 TEST(ParserTest, ExprRecordEmptyTest) { expr_test("{}", expr::record_t{{}}); }
@@ -488,18 +490,19 @@ TEST(ParserTest, ExprRecordEmptyTest) { expr_test("{}", expr::record_t{{}}); }
 TEST(ParserTest, ExprRecordSingleFieldTest)
 {
     expr_test("{value: 42}",
-              expr::record_t{make_vector<expr::record_t::field_t>(expr::record_t::field_t{
-                  .name = token_t::k_identifier("value"), .value = expr::literal_t{token_t::l_integer("42")}})});
+              expr::record_t{make_vector2<expr::record_t::field_t>(
+                  expr::record_t::field_t{.name  = token_t::k_identifier("value"),
+                                          .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("42")}}})});
 }
 
 TEST(ParserTest, ExprRecordTrailingCommaTest)
 {
     expr_test("{a: 1, b: 2, }",
-              expr::record_t{make_vector<expr::record_t::field_t>(
+              expr::record_t{make_vector2<expr::record_t::field_t>(
                   expr::record_t::field_t{.name  = token_t::k_identifier("a"),
-                                          .value = expr::literal_t{token_t::l_integer("1")}},
+                                          .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("1")}}},
                   expr::record_t::field_t{.name  = token_t::k_identifier("b"),
-                                          .value = expr::literal_t{token_t::l_integer("2")}})});
+                                          .value = expr::expr_t{"", expr::literal_t{token_t::l_integer("2")}}})});
 }
 
 TEST(ParserTest, ExprRecordPrecedenceTest)
@@ -507,15 +510,19 @@ TEST(ParserTest, ExprRecordPrecedenceTest)
     expr_test(
         "{sum: a + b, product: c * d}.sum",
         expr::field_t{
-            e(expr::record_t{make_vector<expr::record_t::field_t>(
-                expr::record_t::field_t{.name  = token_t::k_identifier("sum"),
-                                        .value = expr::binary_t{token_t::p_plus("+"),
-                                                                e(expr::identifier_t{token_t::k_identifier("a")}),
-                                                                e(expr::identifier_t{token_t::k_identifier("b")})}},
-                expr::record_t::field_t{.name  = token_t::k_identifier("product"),
-                                        .value = expr::binary_t{token_t::p_asterisk("*"),
-                                                                e(expr::identifier_t{token_t::k_identifier("c")}),
-                                                                e(expr::identifier_t{token_t::k_identifier("d")})}})}),
+            e(expr::record_t{make_vector2<expr::record_t::field_t>(
+                expr::record_t::field_t{
+                    .name  = token_t::k_identifier("sum"),
+                    .value = expr::expr_t{"",
+                                          expr::binary_t{token_t::p_plus("+"),
+                                                         e(expr::identifier_t{token_t::k_identifier("a")}),
+                                                         e(expr::identifier_t{token_t::k_identifier("b")})}}},
+                expr::record_t::field_t{
+                    .name  = token_t::k_identifier("product"),
+                    .value = expr::expr_t{"",
+                                          expr::binary_t{token_t::p_asterisk("*"),
+                                                         e(expr::identifier_t{token_t::k_identifier("c")}),
+                                                         e(expr::identifier_t{token_t::k_identifier("d")})}}})}),
             token_t::k_identifier("sum")});
 }
 
@@ -558,11 +565,12 @@ TEST(ParserTest, ExprTuplePrecedenceTest)
 TEST(ParserTest, ExprIfTest)
 {
     expr_test("if a && b => c",
-              expr::if_t{make_vector<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
-                  .condition   = e(expr::binary_t{token_t::p_and_and("&&"),
-                                                e(expr::identifier_t{token_t::k_identifier("a")}),
-                                                e(expr::identifier_t{token_t::k_identifier("b")})}),
-                  .then_branch = e(expr::identifier_t{token_t::k_identifier("c")})})});
+              expr::if_t{make_vector2<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
+                  .condition   = expr::expr_t{"",
+                                            expr::binary_t{token_t::p_and_and("&&"),
+                                                           e(expr::identifier_t{token_t::k_identifier("a")}),
+                                                           e(expr::identifier_t{token_t::k_identifier("b")})}},
+                  .then_branch = expr::expr_t{"", expr::identifier_t{token_t::k_identifier("c")}}})});
 }
 
 TEST(ParserTest, ExprIfElseIfTest)
@@ -571,17 +579,19 @@ TEST(ParserTest, ExprIfElseIfTest)
         if x < 10 => "small"
         else if x < 20 => "medium"
     )",
-              expr::if_t{make_vector<expr::if_t::conditional_branch_t>(
+              expr::if_t{make_vector2<expr::if_t::conditional_branch_t>(
                   expr::if_t::conditional_branch_t{
-                      .condition   = e(expr::binary_t{token_t::p_less("<"),
-                                                    e(expr::identifier_t{token_t::k_identifier("x")}),
-                                                    e(expr::literal_t{token_t::l_integer("10")})}),
-                      .then_branch = e(expr::literal_t{token_t::l_string("\"small\"")})},
+                      .condition   = expr::expr_t{"",
+                                                expr::binary_t{token_t::p_less("<"),
+                                                               e(expr::identifier_t{token_t::k_identifier("x")}),
+                                                               e(expr::literal_t{token_t::l_integer("10")})}},
+                      .then_branch = expr::expr_t{"", expr::literal_t{token_t::l_string("\"small\"")}}},
                   expr::if_t::conditional_branch_t{
-                      .condition   = e(expr::binary_t{token_t::p_less("<"),
-                                                    e(expr::identifier_t{token_t::k_identifier("x")}),
-                                                    e(expr::literal_t{token_t::l_integer("20")})}),
-                      .then_branch = e(expr::literal_t{token_t::l_string("\"medium\"")})})});
+                      .condition   = expr::expr_t{"",
+                                                expr::binary_t{token_t::p_less("<"),
+                                                               e(expr::identifier_t{token_t::k_identifier("x")}),
+                                                               e(expr::literal_t{token_t::l_integer("20")})}},
+                      .then_branch = expr::expr_t{"", expr::literal_t{token_t::l_string("\"medium\"")}}})});
 }
 
 TEST(ParserTest, ExprIfElseTest)
@@ -590,9 +600,9 @@ TEST(ParserTest, ExprIfElseTest)
         if isValid => "valid"
         else => "invalid"
     )",
-              expr::if_t{make_vector<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
-                             .condition   = e(expr::identifier_t{token_t::k_identifier("isValid")}),
-                             .then_branch = e(expr::literal_t{token_t::l_string("\"valid\"")})}),
+              expr::if_t{make_vector2<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
+                             .condition   = expr::expr_t{"", expr::identifier_t{token_t::k_identifier("isValid")}},
+                             .then_branch = expr::expr_t{"", expr::literal_t{token_t::l_string("\"valid\"")}}}),
                          e(expr::literal_t{token_t::l_string("\"invalid\"")})});
 }
 
@@ -604,18 +614,21 @@ TEST(ParserTest, ExprIfElseIfElseTest)
         else if score >= 80 => "B"
         else => "C"
     )",
-        expr::if_t{make_vector<expr::if_t::conditional_branch_t>(
-                       expr::if_t::conditional_branch_t{
-                           .condition   = e(expr::binary_t{token_t::p_greater_equal(">="),
-                                                         e(expr::identifier_t{token_t::k_identifier("score")}),
-                                                         e(expr::literal_t{token_t::l_integer("90")})}),
-                           .then_branch = e(expr::literal_t{token_t::l_string("\"A\"")})},
-                       expr::if_t::conditional_branch_t{
-                           .condition   = e(expr::binary_t{token_t::p_greater_equal(">="),
-                                                         e(expr::identifier_t{token_t::k_identifier("score")}),
-                                                         e(expr::literal_t{token_t::l_integer("80")})}),
-                           .then_branch = e(expr::literal_t{token_t::l_string("\"B\"")})}),
-                   e(expr::literal_t{token_t::l_string("\"C\"")})});
+        expr::if_t{
+            make_vector2<expr::if_t::conditional_branch_t>(
+                expr::if_t::conditional_branch_t{
+                    .condition   = expr::expr_t{"",
+                                              expr::binary_t{token_t::p_greater_equal(">="),
+                                                             e(expr::identifier_t{token_t::k_identifier("score")}),
+                                                             e(expr::literal_t{token_t::l_integer("90")})}},
+                    .then_branch = expr::expr_t{"", expr::literal_t{token_t::l_string("\"A\"")}}},
+                expr::if_t::conditional_branch_t{
+                    .condition   = expr::expr_t{"",
+                                              expr::binary_t{token_t::p_greater_equal(">="),
+                                                             e(expr::identifier_t{token_t::k_identifier("score")}),
+                                                             e(expr::literal_t{token_t::l_integer("80")})}},
+                    .then_branch = expr::expr_t{"", expr::literal_t{token_t::l_string("\"B\"")}}}),
+            e(expr::literal_t{token_t::l_string("\"C\"")})});
 }
 
 TEST(ParserTest, ExprIfBlockTest)
@@ -625,9 +638,9 @@ TEST(ParserTest, ExprIfBlockTest)
             a
         end
     )",
-              expr::if_t{make_vector<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
-                  .condition   = e(expr::identifier_t{token_t::k_identifier("isReady")}),
-                  .then_branch = e(expr::block_t{{}, e(expr::identifier_t{token_t::k_identifier("a")})})})});
+              expr::if_t{make_vector2<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
+                  .condition   = expr::expr_t{"", expr::identifier_t{token_t::k_identifier("isReady")}},
+                  .then_branch = expr::expr_t{"", expr::block_t{{}, e(expr::identifier_t{token_t::k_identifier("a")})}}})});
 }
 
 TEST(ParserTest, ExprIfElseMixedBlockTest)
@@ -640,13 +653,14 @@ TEST(ParserTest, ExprIfElseMixedBlockTest)
             b + c
         end
     )",
-        expr::if_t{make_vector<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
-                       .condition   = e(expr::identifier_t{token_t::k_identifier("condition")}),
-                       .then_branch = e(expr::block_t{{}, e(expr::identifier_t{token_t::k_identifier("a")})})}),
-                   e(expr::block_t{{},
-                                   e(expr::binary_t{token_t::p_plus("+"),
-                                                    e(expr::identifier_t{token_t::k_identifier("b")}),
-                                                    e(expr::identifier_t{token_t::k_identifier("c")})})})});
+        expr::if_t{
+            make_vector2<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
+                .condition   = expr::expr_t{"", expr::identifier_t{token_t::k_identifier("condition")}},
+                .then_branch = expr::expr_t{"", expr::block_t{{}, e(expr::identifier_t{token_t::k_identifier("a")})}}}),
+            e(expr::block_t{{},
+                            e(expr::binary_t{token_t::p_plus("+"),
+                                             e(expr::identifier_t{token_t::k_identifier("b")}),
+                                             e(expr::identifier_t{token_t::k_identifier("c")})})})});
 }
 
 TEST(ParserTest, ExprIfValueTest)
@@ -655,11 +669,12 @@ TEST(ParserTest, ExprIfValueTest)
               expr::binary_t{
                   token_t::p_asterisk("*"),
                   e(expr::grouping_t{e(expr::if_t{
-                      make_vector<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
-                          .condition   = e(expr::binary_t{token_t::p_greater(">"),
-                                                        e(expr::identifier_t{token_t::k_identifier("x")}),
-                                                        e(expr::literal_t{token_t::l_integer("0")})}),
-                          .then_branch = e(expr::identifier_t{token_t::k_identifier("x")})}),
+                      make_vector2<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
+                          .condition   = expr::expr_t{"",
+                                                    expr::binary_t{token_t::p_greater(">"),
+                                                                   e(expr::identifier_t{token_t::k_identifier("x")}),
+                                                                   e(expr::literal_t{token_t::l_integer("0")})}},
+                          .then_branch = expr::expr_t{"", expr::identifier_t{token_t::k_identifier("x")}}}),
                       e(expr::unary_t{token_t::p_minus("-"), e(expr::identifier_t{token_t::k_identifier("x")})})})}),
                   e(expr::literal_t{token_t::l_integer("2")})});
 }

--- a/test/parser/parser-expr-test.cpp
+++ b/test/parser/parser-expr-test.cpp
@@ -633,14 +633,15 @@ TEST(ParserTest, ExprIfElseIfElseTest)
 
 TEST(ParserTest, ExprIfBlockTest)
 {
-    expr_test(R"(
+    expr_test(
+        R"(
         if isReady then
             a
         end
     )",
-              expr::if_t{make_vector2<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
-                  .condition   = expr::expr_t{"", expr::identifier_t{token_t::k_identifier("isReady")}},
-                  .then_branch = expr::expr_t{"", expr::block_t{{}, e(expr::identifier_t{token_t::k_identifier("a")})}}})});
+        expr::if_t{make_vector2<expr::if_t::conditional_branch_t>(expr::if_t::conditional_branch_t{
+            .condition   = expr::expr_t{"", expr::identifier_t{token_t::k_identifier("isReady")}},
+            .then_branch = expr::expr_t{"", expr::block_t{{}, e(expr::identifier_t{token_t::k_identifier("a")})}}})});
 }
 
 TEST(ParserTest, ExprIfElseMixedBlockTest)

--- a/test/parser/parser-stmt-test.cpp
+++ b/test/parser/parser-stmt-test.cpp
@@ -2,17 +2,13 @@
 #include "loxmocha/ast/expr.hpp"
 #include "loxmocha/ast/stmt.hpp"
 #include "loxmocha/ast/token.hpp"
-#include "loxmocha/memory/safe_pointer.hpp"
 
 #include "gtest/gtest.h"
 
 using namespace loxmocha;
 using namespace loxmocha::test::helpers;
 
-TEST(ParserTest, StmtExprTest)
-{
-    stmt_test("42", stmt::expr_t{safe_ptr<expr::expr_t>::make(expr::literal_t{token_t::l_integer("42")})});
-}
+TEST(ParserTest, StmtExprTest) { stmt_test("42", stmt::expr_t{e(expr::literal_t{token_t::l_integer("42")})}); }
 
 TEST(ParserTest, StmtAssignTest)
 {
@@ -23,9 +19,7 @@ TEST(ParserTest, StmtAssignTest)
                                    e(expr::call_t{e(expr::identifier_t{token_t::k_identifier("my_func")}),
                                                   make_vector<expr::expr_t>(expr::literal_t{token_t::l_integer("10")}),
                                                   {}}),
-                                   e(expr::literal_t{token_t::l_integer("500")})
-
-                  })});
+                                   e(expr::literal_t{token_t::l_integer("500")})})});
 }
 
 TEST(ParserTest, StmtComplexTargetAssignTest)
@@ -36,18 +30,14 @@ TEST(ParserTest, StmtComplexTargetAssignTest)
             e(expr::field_t{e(expr::index_t{e(expr::identifier_t{token_t::k_identifier("my_array")}),
                                             e(expr::binary_t{token_t::p_plus("+"),
                                                              e(expr::literal_t{token_t::l_integer("2")}),
-                                                             e(expr::identifier_t{token_t::k_identifier("index")})})
-
-                            }),
+                                                             e(expr::identifier_t{token_t::k_identifier("index")})})}),
                             token_t::k_identifier("field")}),
             e(expr::call_t{e(expr::identifier_t{token_t::k_identifier("another_func")}),
                            make_vector<expr::expr_t>(
 
                                expr::identifier_t{token_t::k_identifier("arg1")},
                                expr::identifier_t{token_t::k_identifier("arg2")}),
-                           {}
-
-            })});
+                           {}})});
 }
 
 TEST(ParserTest, StmtDeclTest)

--- a/test/parser/parser-type-test.cpp
+++ b/test/parser/parser-type-test.cpp
@@ -60,18 +60,19 @@ TEST(ParserTest, TypeRecordTest)
         b: string
     end
     )",
-        type::record_t{make_vector<type::record_t::field_t>(
+        type::record_t{make_vector2<type::record_t::field_t>(
             type::record_t::field_t{.name = token_t::k_identifier("a"),
-                                    .type = type::identifier_t{token_t::k_identifier("int")}},
+                                    .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}},
             type::record_t::field_t{.name = token_t::k_identifier("b"),
-                                    .type = type::identifier_t{token_t::k_identifier("string")}})});
+                                    .type = type::type_t{"", type::identifier_t{token_t::k_identifier("string")}}})});
 }
 
 TEST(ParserTest, TypeEmptyRecordTest) { type_test("rec end", type::record_t{{}}); }
 
 TEST(ParserTest, TypeTaggedTest)
 {
-    type_test(R"(
+    type_test(
+        R"(
     choice
         FirstTag: int,
         SecondTag: rec
@@ -80,27 +81,31 @@ TEST(ParserTest, TypeTaggedTest)
         end
     end
     )",
-              type::tagged_t{make_vector<type::tagged_t::tag_t>(
-                  type::tagged_t::tag_t{.name = token_t::k_identifier("FirstTag"),
-                                        .type = type::identifier_t{token_t::k_identifier("int")}},
-                  type::tagged_t::tag_t{
-                      .name = token_t::k_identifier("SecondTag"),
-                      .type = type::record_t{make_vector<type::record_t::field_t>(
-                          type::record_t::field_t{.name = token_t::k_identifier("name"),
-                                                  .type = type::identifier_t{token_t::k_identifier("string")}},
-                          type::record_t::field_t{.name = token_t::k_identifier("value"),
-                                                  .type = type::identifier_t{token_t::k_identifier("int")}})
+        type::tagged_t{make_vector2<type::tagged_t::tag_t>(
+            type::tagged_t::tag_t{.name = token_t::k_identifier("FirstTag"),
+                                  .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}},
+            type::tagged_t::tag_t{
+                .name = token_t::k_identifier("SecondTag"),
+                .type =
+                    type::type_t{"",
+                                 type::record_t{make_vector2<type::record_t::field_t>(
+                                     type::record_t::field_t{
+                                         .name = token_t::k_identifier("name"),
+                                         .type = type::type_t{"", type::identifier_t{token_t::k_identifier("string")}}},
+                                     type::record_t::field_t{
+                                         .name = token_t::k_identifier("value"),
+                                         .type = type::type_t{"", type::identifier_t{token_t::k_identifier("int")}}})}
 
-                      }}
+                    }}
 
-                  )});
+            )});
 }
 
 TEST(ParserTest, TypeSingleTaggedTest)
 {
     type_test("choice SingleTag: () end",
-              type::tagged_t{make_vector<type::tagged_t::tag_t>(
-                  type::tagged_t::tag_t{.name = token_t::k_identifier("SingleTag"), .type = type::tuple_t{{}}})});
+              type::tagged_t{make_vector2<type::tagged_t::tag_t>(type::tagged_t::tag_t{
+                  .name = token_t::k_identifier("SingleTag"), .type = type::type_t{"", type::tuple_t{{}}}})});
 }
 
 TEST(ParserTest, TypeReferenceTest)
@@ -154,15 +159,16 @@ TEST(ParserTest, TypeGroupingTest)
 
 TEST(ParserTest, TypeFunctionPrecedenceTest)
 {
-    type_test("fun(int[10], rec a: string end): arr[5]",
-              type::function_t{
-                  make_vector<type::type_t>(type::array_t{t(type::identifier_t{token_t::k_identifier("int")}),
-                                                          e(expr::literal_t{token_t::l_integer("10")})},
-                                            type::record_t{make_vector<type::record_t::field_t>(type::record_t::field_t{
-                                                .name = token_t::k_identifier("a"),
-                                                .type = type::identifier_t{token_t::k_identifier("string")}})}),
-                  t(type::array_t{t(type::identifier_t{token_t::k_identifier("arr")}),
-                                  e(expr::literal_t{token_t::l_integer("5")})})});
+    type_test(
+        "fun(int[10], rec a: string end): arr[5]",
+        type::function_t{make_vector<type::type_t>(
+                             type::array_t{t(type::identifier_t{token_t::k_identifier("int")}),
+                                           e(expr::literal_t{token_t::l_integer("10")})},
+                             type::record_t{make_vector2<type::record_t::field_t>(type::record_t::field_t{
+                                 .name = token_t::k_identifier("a"),
+                                 .type = type::type_t{"", type::identifier_t{token_t::k_identifier("string")}}})}),
+                         t(type::array_t{t(type::identifier_t{token_t::k_identifier("arr")}),
+                                         e(expr::literal_t{token_t::l_integer("5")})})});
 }
 
 TEST(ParserTest, TypeFunctionArrayTest)


### PR DESCRIPTION
This adds the source manager to manage source files and lookup of source locations within a source file.
To enable the lookup of source positions for nodes in the AST we add the span (string_view) of the parsed node in the text to the nodes in the AST.
To then demonstrate this we add a pretty printer and update the loxmc frontend to parse and output the pretty printed tree